### PR TITLE
fixed video_encode_values_array options

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
         <item>6</item>
         <item>4</item>
         <item>2</item>
+	<item>0</item>
     </string-array>
 
     <!-- Logs -->


### PR DESCRIPTION
Dear @The1only , in strings.xml, we found there is a different number of elements in "video_encode_array" and "video_encode_values_array", which may cause setting issue. This PR added an item "0" in video_encode_values_array for the item "Very Slow" in video_encode_array.

Please review it and let me know if it is correct.

Best,
-- Luke 