### PR TITLE
Mavic Pro encoding and do_set_motion_velocity fix

### DIFF
--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -1803,10 +1803,10 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
     //    Log.i(TAG, "do_set_motion_velocity");
 
         // If we use yaw rate...
-        if((mask & 0b0000100000000000) == 0){  mYaw = yaw; }
-        if((mask & 0b0000000000001000) == 0){  mPitch = y; }
-        if((mask & 0b0000000000010000) == 0){  mRoll = x; }
-        if((mask & 0b0000000000100000) == 0){  mThrottle = z;}
+        if((mask & 0b0000100000000000) != 0){  mYaw = yaw; }
+        if((mask & 0b0000000000001000) != 0){  mPitch = y; }
+        if((mask & 0b0000000000010000) != 0){  mRoll = x; }
+        if((mask & 0b0000000000100000) != 0){  mThrottle = z;}
 
         // Only allow velocity movement in P mode...
         if( rcmode == HardwareState.FlightModeSwitch.POSITION_ONE) { // != avtivemode || rcmode != HardwareState.FlightModeSwitch.POSITION_TWO) {

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -762,6 +762,7 @@ public class MainActivity extends AppCompatActivity implements DJICodecManager.Y
             case INSPIRE_1_PRO:
             case INSPIRE_1_RAW:     // Verified...
             case MAVIC_AIR:         // Verified...
+            case MAVIC_PRO:
                 return true;
         }
 


### PR DESCRIPTION
Hello @The1only i encountered two problems that are fixed with my last two commits.

1. The Mavic Pro requires the old encoding, crashes the app otherwise.

2. In do_set_motion_velocity the mask AND bit must be set for for a valid value, therefore the check must be != 0 instead of == 0.

I tested both changes with a Mavic Pro, i have no other drones at hand right now.