### PR TITLE
Added FTP Manager

### DIFF
--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -13,6 +13,7 @@ import com.MAVLink.common.msg_attitude;
 import com.MAVLink.common.msg_autopilot_version;
 import com.MAVLink.common.msg_battery_status;
 import com.MAVLink.common.msg_command_ack;
+import com.MAVLink.common.msg_file_transfer_protocol;
 import com.MAVLink.common.msg_global_position_int;
 import com.MAVLink.common.msg_gps_raw_int;
 import com.MAVLink.common.msg_heartbeat;
@@ -33,6 +34,7 @@ import com.MAVLink.common.msg_statustext;
 import com.MAVLink.common.msg_sys_status;
 import com.MAVLink.common.msg_vfr_hud;
 import com.MAVLink.common.msg_vibration;
+import com.MAVLink.common.msg_file_transfer_protocol;
 import com.MAVLink.enums.GPS_FIX_TYPE;
 import com.MAVLink.enums.MAV_AUTOPILOT;
 import com.MAVLink.enums.MAV_CMD;
@@ -45,6 +47,8 @@ import com.MAVLink.enums.MAV_RESULT;
 import com.MAVLink.enums.MAV_STATE;
 import com.MAVLink.enums.MAV_TYPE;
 
+import com.google.android.gms.common.util.ArrayUtils;
+
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
@@ -55,6 +59,7 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.nio.ByteBuffer;
 
 import androidx.annotation.NonNull;
 import dji.common.camera.SettingsDefinitions;
@@ -205,6 +210,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
     public boolean mAutonomy = false;
     public int mAirBorn = 0;
     int mission_loaded = -1;
+    public boolean mission_started = true;
 
     DroneModel(MainActivity parent, DatagramSocket socket, boolean sim) {
         this.parent = parent;
@@ -1014,6 +1020,67 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
         sendMessage(msg);
     }
 
+    void send_command_ftp_string_ack(int message_id, String data, byte[] header) {
+        msg_file_transfer_protocol msg = new msg_file_transfer_protocol();
+        byte[] byteString = data.getBytes();
+        short[] shortArray = new short[251];
+
+
+        if(header != null){
+            for(int i = 0; i < header.length; i++) {
+                short s = (short)(header[i] & 0xFF);
+                shortArray[i] = s;
+            }
+        }
+
+        int sizeCounter = 0;
+        for (int i = 0; i < byteString.length; i++){
+            int added = 12 + i;
+            short s = byteString[i];
+            shortArray[added] = s;
+            sizeCounter += 1;
+        }
+        shortArray[3] = (short)128;
+        shortArray[4] = (short)sizeCounter;
+        msg.payload = shortArray;
+        msg.msgid = message_id;
+
+        sendMessage(msg);
+    }
+
+    void send_command_ftp_bytes_ack(int message_id, byte[] data) {
+        msg_file_transfer_protocol msg = new msg_file_transfer_protocol();
+        short[] shortArray = new short[data.length];
+        for (int i = 0; i < data.length; i++){
+            short s = (short)(data[i] & 0xFF);
+            shortArray[i] = s;
+        }
+
+        shortArray[3] = (short)128;
+
+        msg.payload = shortArray;
+        msg.msgid = message_id;
+
+        sendMessage(msg);
+    }
+
+    void send_command_ftp_nak(int message_id, int errorCode, int failCode) {
+        msg_file_transfer_protocol msg = new msg_file_transfer_protocol();
+        short[] shortArray = new short[251];
+
+        shortArray[3] = (short)129; //nak code
+        if(failCode != 0){
+            shortArray[4] = (short)2; //error size
+            shortArray[13] = (short)failCode;
+        } else {
+            shortArray[4] = (short)1; //error size
+        }
+        shortArray[12] = (short)errorCode; // the error code
+
+        msg.msgid = message_id;
+        sendMessage(msg);
+    }
+
     private void send_global_position_int() {
         msg_global_position_int msg = new msg_global_position_int();
 
@@ -1567,6 +1634,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
 
     void startWaypointMission() {
         mAutonomy = false;
+        mission_started = true;
         parent.logMessageDJI("start WaypointMission()");
 
         if (getWaypointMissionOperator() == null) {
@@ -1594,6 +1662,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
 
     public void stopWaypointMission() {
         mAutonomy = false;
+        mission_started = false;
         if (getWaypointMissionOperator() == null) {
             parent.logMessageDJI("stopWaypointMission() - mWaypointMissionOperator null");
             return;

--- a/app/src/main/java/sq/rogue/rosettadrone/FTPManager.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/FTPManager.java
@@ -1,0 +1,231 @@
+package sq.rogue.rosettadrone;
+
+import com.MAVLink.common.msg_file_transfer_protocol;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+import static com.MAVLink.common.msg_file_transfer_protocol.MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL;
+import static sq.rogue.rosettadrone.util.safeSleep;
+
+public class FTPManager {
+    private MainActivity parent;
+    private DroneModel mModel;
+    private File currentFile;
+    private byte[][] currentFileInPacket;
+
+    public FTPManager(MainActivity parent, DroneModel mModel) {
+        this.parent = parent;
+        this.mModel = mModel;
+        this.currentFile = null;
+        this.currentFileInPacket = null;
+    }
+
+    public void manage_ftp(msg_file_transfer_protocol msg_ftp_item){
+        int session_id = new Short(msg_ftp_item.payload[2]).intValue();
+        int opCode = new Short(msg_ftp_item.payload[3]).intValue();
+        int offset = getOffset(msg_ftp_item.payload);
+//      DEBUG
+//        parent.logMessageDJI("opCode: " + opCode);
+//        parent.logMessageDJI("session_id: " + session_id);
+//        parent.logMessageDJI("Offset: " + offset);
+//        parent.logMessageDJI("code was " + opCode);
+        switch (opCode) {
+            case 3: // Return list
+                fetchFiles(offset);
+                break;
+            case 4: // Open file for reading
+                int file_id = new Short(msg_ftp_item.payload[12]).intValue();
+                openFile(file_id, session_id);
+                break;
+            case 5: // Read file
+                readFile(session_id, offset, msg_ftp_item.payload);
+                break;
+            case 8: // Remove file
+                break;
+        }
+    }
+    public int getOffset(short[] payload){
+//        parent.logMessageDJI("CAME HERE!");
+        byte[] byteArray = new byte[4];
+
+        for(int i = 0; i <= 3; i++){
+            int added = 8 + i;
+            short x = new Short(payload[added]);
+            byteArray[i] = (byte)(x & 0xff);
+        };
+
+        int offset = ByteBuffer.wrap(byteArray).getInt();
+        return offset;
+    }
+
+    public void fetchFiles(int offset){
+        parent.initMediaManager();
+        safeSleep(1500);
+        parent.logMessageDJI("Getting files");
+        parent.getFilesDir();
+        if(parent.mediaFileList.size() < offset) {
+            mModel.send_command_ftp_nak(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, 10, 0);
+        } else {
+            String dir_items = "";
+            String add_dir = "";
+            for (int i = offset; i < parent.mediaFileList.size(); i++) {
+                add_dir = "F" + parent.mediaFileList.get(i).getFileName() + "\\t" + parent.mediaFileList.get(i).getFileSize() + "\\0";
+                if (dir_items.getBytes().length + add_dir.getBytes().length < (251 - 12)) {
+                    dir_items += add_dir;
+                }
+            }
+            parent.logMessageDJI("total: " + dir_items.getBytes().length + ": " + dir_items);
+
+            mModel.send_command_ftp_string_ack(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, dir_items, null);
+        }
+    }
+
+    public void openFile(int file_id, int session_id){
+        parent.logMessageDJI("Download file by index " + file_id);
+        parent.currentProgress = 0;
+        if(parent.lastDownloadedIndex != file_id) {
+            parent.downloadFileByIndex(file_id);
+            // wait for done
+            while (parent.currentProgress != -1){
+                safeSleep(1000);
+                parent.logMessageDJI("Waiting for current progress: " + parent.currentProgress);
+            };
+        }
+        if(!parent.downloadError){
+            parent.logMessageDJI("No error while downloading");
+            currentFileInPacket = new byte[0][0];
+            currentFile = null;
+            parent.logMessageDJI("Reset currentfile and currentfileinpackets");
+            byte[] header = new byte[12];
+            header[2] = (byte)session_id;
+            header[4] = 4;
+            parent.logMessageDJI(parent.last_downloaded_file);
+            try {
+                currentFile = new File(parent.last_downloaded_file);
+            } catch (Exception e){
+                parent.logMessageDJI(e.toString());
+            }
+            // convert to byte array
+            try (InputStream is = new FileInputStream(currentFile)) {
+                if (currentFile.length() > Integer.MAX_VALUE) {
+                    mModel.send_command_ftp_nak(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, 1, 0);
+                    parent.logMessageDJI("File to big!");
+                }
+                parent.logMessageDJI("read file to bytes...");
+
+                byte[] fetchedFile = readFileToBytes(currentFile);
+                // byte [x,2,e,d,f,ge,e,e,s,df,s]
+
+                parent.logMessageDJI("Current file in bytes: " + fetchedFile.length);
+
+                int payload_data_size = (251-12);
+                int total_file_size = (int) currentFile.length();
+                float total_packets_float = (float) total_file_size/payload_data_size;
+                int total_packets = (int) Math.ceil(total_packets_float);
+                int bytes_to_add_size = 0;
+                int current_byte = 0;
+
+                parent.logMessageDJI("Getting packets: " + total_packets);
+                currentFileInPacket = new byte[total_packets][];
+                try {
+                    for (int i = 0; i < total_packets; i++) {
+                        current_byte = payload_data_size * i; // 5.802.442 (+13 = 5.802.455)
+                        bytes_to_add_size = payload_data_size; //239
+                        if (current_byte + payload_data_size > fetchedFile.length) {
+                            bytes_to_add_size = fetchedFile.length - current_byte;
+                            parent.logMessageDJI("Getting a total of last byte size " + bytes_to_add_size); //13
+                        }
+                        currentFileInPacket[i] = new byte[bytes_to_add_size];
+
+                        for (int j = 0; j < bytes_to_add_size; j++) {
+                            currentFileInPacket[i][j] = fetchedFile[current_byte + j];
+                        }
+                    }
+                    parent.logMessageDJI("Current file in bytes: " + total_file_size + ", total packets: " + total_packets);
+                } catch (Exception e){
+                    parent.logMessageDJI("Exception: " + e.toString());
+                }
+
+            } catch (FileNotFoundException e) {
+                mModel.send_command_ftp_nak(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, 10, 0);
+                parent.logMessageDJI("FileNotFoundException: " + e.toString());
+                return;
+            } catch (IOException e) {
+                mModel.send_command_ftp_nak(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, 1, 0);
+                parent.logMessageDJI("IOException: " + e.toString());
+                return;
+            }
+            int file_size = (int)currentFile.length();
+            parent.logMessageDJI("File size: " + file_size);
+            mModel.send_command_ftp_string_ack(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, file_size + "", null);
+            parent.logMessageDJI("Opened image " + currentFile.getName());
+        } else {
+            parent.logMessageDJI("There was an error");
+            mModel.send_command_ftp_nak(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, 1, 0);
+        }
+    }
+
+    public void readFile(int session_id, int offset, short[] payload){
+        try { //remove this try catch block after debugging
+            int bytes_to_add_size = currentFileInPacket[offset].length;
+            int bytes_with_header_size = bytes_to_add_size + 12;
+
+            byte[] data = new byte[bytes_with_header_size];
+
+//          Set offset from original payload
+            for (int i = 8; i <= 12; i++) {
+                short x = new Short(payload[i]);
+                data[i] = (byte) (x & 0xff);
+            }
+//          Set session
+            data[2] = (byte) session_id;
+            data[4] = (byte) bytes_to_add_size;
+
+            if (currentFile == null || currentFile.length() == 0) {
+                parent.logMessageDJI("File is null, sending error code");
+                mModel.send_command_ftp_nak(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, 10, 0);
+                return;
+            }
+            if (offset > (currentFileInPacket.length)) {
+                parent.logMessageDJI("offset > currentFileInPacket.length");
+                mModel.send_command_ftp_nak(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, 6, 0);
+                return;
+            }
+            try {
+//          We only need to rewrite byte 12 to bytes_to_add_size (which is the total bytes in currentFileInPacket[packet])
+//          Then we just read a packet byte by using the offset as packet_id and i from bytes_to_add_size
+                for (int i = 0; i < bytes_to_add_size; i++) {
+                    int added = i + 12;
+                    data[added] = currentFileInPacket[offset][i];
+                }
+                mModel.send_command_ftp_bytes_ack(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, data);
+            } catch (Exception e) {
+                parent.logMessageDJI(e.toString());
+                mModel.send_command_ftp_nak(MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL, 6, 0);
+            }
+        } catch (Exception e) {
+            parent.logMessageDJI(e.toString());
+        }
+    }
+
+    private byte[] readFileToBytes(File file) throws IOException {
+        byte[] bytes = new byte[(int) file.length()];
+        FileInputStream fis = null;
+        try {
+            fis = new FileInputStream(file);
+            //read file into bytes[]
+            fis.read(bytes);
+        } finally {
+            if (fis != null) {
+                fis.close();
+            }
+        }
+        return bytes;
+    }
+}

--- a/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
@@ -15,11 +15,13 @@ import com.MAVLink.common.msg_param_request_read;
 import com.MAVLink.common.msg_param_set;
 import com.MAVLink.common.msg_set_mode;
 import com.MAVLink.common.msg_set_position_target_global_int;
+import com.MAVLink.common.msg_file_transfer_protocol;
 import com.MAVLink.common.msg_set_position_target_local_ned;
 import com.MAVLink.enums.MAV_CMD;
 import com.MAVLink.enums.MAV_MISSION_TYPE;
 import com.MAVLink.enums.MAV_RESULT;
 
+import java.io.File;
 import java.util.ArrayList;
 
 import dji.common.flightcontroller.FlightControllerState;
@@ -70,6 +72,8 @@ import static com.MAVLink.enums.MAV_CMD.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES;
 import static com.MAVLink.enums.MAV_CMD.MAV_CMD_VIDEO_START_CAPTURE;
 import static com.MAVLink.enums.MAV_CMD.MAV_CMD_VIDEO_STOP_CAPTURE;
 import static com.MAVLink.enums.MAV_MISSION_TYPE.MAV_MISSION_TYPE_MISSION;
+import static com.MAVLink.common.msg_file_transfer_protocol.MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL;
+import static com.MAVLink.enums.MAV_GOTO.MAV_GOTO_HOLD_AT_SPECIFIED_POSITION;
 import static sq.rogue.rosettadrone.util.TYPE_WAYPOINT_DISTANCE;
 import static sq.rogue.rosettadrone.util.TYPE_WAYPOINT_MAX_ALTITUDE;
 import static sq.rogue.rosettadrone.util.TYPE_WAYPOINT_MAX_SPEED;
@@ -92,6 +96,7 @@ public class MAVLinkReceiver {
     public boolean curvedFlightPath = true;
     public float flightPathRadius = .2f;
     DroneModel mModel;
+    FTPManager ftpManager;
     private long mTimeStampLastGCSHeartbeat = 0;
     private int mNumGCSWaypoints = 0;
     private int wpState = 0;
@@ -490,6 +495,14 @@ public class MAVLinkReceiver {
                 if (ym != null) {
                     ym.getWaypointList().clear();
                 }
+                break;
+            case MAVLINK_MSG_ID_FILE_TRANSFER_PROTOCOL:
+                msg_file_transfer_protocol msg_ftp_item = (msg_file_transfer_protocol) msg;
+                ftpManager.manage_ftp(msg_ftp_item);
+                break;
+            default:
+                parent.logMessageDJI("Received (unkown) message");
+                parent.logMessageDJI( String.valueOf(msg.msgid));
                 break;
         }
     }

--- a/app/src/main/java/sq/rogue/rosettadrone/RDApplication.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/RDApplication.java
@@ -7,6 +7,9 @@ import com.secneo.sdk.Helper;
 
 import dji.sdk.base.BaseProduct;
 import dji.sdk.sdkmanager.DJISDKManager;
+import dji.sdk.camera.Camera;
+import dji.sdk.products.Aircraft;
+import dji.sdk.products.HandHeld;
 
 public class RDApplication extends Application {
 
@@ -58,6 +61,20 @@ public class RDApplication extends Application {
             simulatorApplication = new DJISimulatorApplication();
             simulatorApplication.setContext(this);
         }
+    }
+
+    public static synchronized Camera getCameraInstance() {
+        if (getProductInstance() == null) return null;
+        Camera camera = null;
+        if (getProductInstance() instanceof Aircraft){
+            camera = ((Aircraft) getProductInstance()).getCamera();
+
+        } else if (getProductInstance() instanceof HandHeld) {
+            camera = ((HandHeld) getProductInstance()).getCamera();
+        } else if (getProductInstance() instanceof HandHeld) {
+            camera = ((HandHeld) getProductInstance()).getCamera();
+        }
+        return camera;
     }
 }
 


### PR DESCRIPTION
Worked on enabling FTP in the Rosetta Drone app.
- Added the FTPManager class containing FTP functions
- Added camera instance in RDApplication
- Added the FTP MAVLink commands to MAVLinkReceiver
- Added the DJI Media manager to MainActivity
- Added the send ack and nak for FTP commands in DroneModel

Current FTP Features:
- Get all files on SD card with filename and filesize. : Called "FetchFiles"
- Download file from drone to phone (and automatically converts it to a byte array) : Called "OpenFile"
- Download one file from phone to script. : Called "ReadFile"

Before you can download (read) a file, you will need to open the file so it will be prepared into bytearrays.

**Important**
The app crashes after downloading a second file around 40% - 50% of downloading the packets.

Todo in FTP:
- Add more FTP functions (looking at MAVLink's protocol, this should be doable)
- Fix the crash when downloading the second file