### PR TITLE
[DO-NOT-MERGE] Mini 2 Support and waypoint optimizations

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>rosettadrone</name>
+	<comment>Project rosettadrone created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1629740536633</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/.project
+++ b/.project
@@ -16,12 +16,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1629740536633</id>
+			<id>1671828899421</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# RosettaDrone 2 fork with unofficial Mini 2 Support
+
+Uses Frida to Support the Mini 2 by spoofing the DroneType as Mavic Air 2 and the Camera as Mavic Mini
+
+Known Issues:
+- No Yaw limits for Gimbal, potential damage source
+- Simulator disconnect while flight makes the gimbal go crazy sometimes, unknown if this can cause potential damage. Persists on short restarts, on coldstart usually works a few times.
+- IMU shows abnormal, but no issues occur. Doesnt happen with Mavic Mini Camera spoofed
+- Mavic Mini Camera doesnt lets you set raw etc in the UX SDK, however its possible to set it in the DJI Fly app and it just keeps the values
+
+**Use on your own risk.**
+
+You will need to additionally have https://gist.github.com/m4xw/bcd66abb39f711399f7ff2e5b6be20e3 on your SDCard.
+The location is specified in gadget.config.so (fake shared lib, just a json)
+
 # RosettaDrone 2 is now updated to DJI SDK 4.14 beta 1...
 
 Rosetta Drone 2 tested on **DJI Air, Mavic 2 x and Matrice 210 V2, Mavic Pro, Mavic AIR series

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Uses Frida to Support the Mini 2 by spoofing the DroneType as Mavic Air 2 and th
 
 Known Issues:
 - No Yaw limits for Gimbal, potential damage source
-- Simulator disconnect while flight makes the gimbal go crazy sometimes, unknown if this can cause potential damage. Persists on short restarts, on coldstart usually works a few times.
+- Simulator without cooling can cause overheating
+- Rear LED becomes disabled without resetting drone parameters
 - IMU shows abnormal, but no issues occur. Doesnt happen with Mavic Mini Camera spoofed
 - Mavic Mini Camera doesnt lets you set raw etc in the UX SDK, however its possible to set it in the DJI Fly app and it just keeps the values
 

--- a/app/.project
+++ b/app/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app</name>
+	<comment>Project app created by Buildship.</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1629740536627</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/app/.project
+++ b/app/.project
@@ -22,12 +22,12 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1629740536627</id>
+			<id>1671828899380</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'com.squareup:otto:1.3.8'
-    implementation('com.dji:dji-sdk:4.16.1', {
+    implementation('com.dji:dji-sdk:4.16.4', {
         /**
          * Uncomment the "library-anti-distortion" if your app does not need Anti Distortion for Mavic 2 Pro and Mavic 2 Zoom.
          * Uncomment the "fly-safe-database" if you need database for release, or we will download it when DJISDKManager.getInstance().registerApp
@@ -108,9 +108,9 @@ dependencies {
         exclude module: 'library-anti-distortion'
         exclude module: 'fly-safe-database'
     })
-    compileOnly 'com.dji:dji-sdk-provided:4.16.1'
+    compileOnly 'com.dji:dji-sdk-provided:4.16.4'
 
-    implementation 'com.dji:dji-uxsdk:4.15'
+    implementation 'com.dji:dji-uxsdk:4.16'
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'com.squareup:otto:1.3.8'
-    implementation('com.dji:dji-sdk:4.15', {
+    implementation('com.dji:dji-sdk:4.16.1', {
         /**
          * Uncomment the "library-anti-distortion" if your app does not need Anti Distortion for Mavic 2 Pro and Mavic 2 Zoom.
          * Uncomment the "fly-safe-database" if you need database for release, or we will download it when DJISDKManager.getInstance().registerApp
@@ -108,7 +108,7 @@ dependencies {
         exclude module: 'library-anti-distortion'
         exclude module: 'fly-safe-database'
     })
-    compileOnly 'com.dji:dji-sdk-provided:4.15'
+    compileOnly 'com.dji:dji-sdk-provided:4.16.1'
 
     implementation 'com.dji:dji-uxsdk:4.15'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -98,7 +98,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'com.squareup:otto:1.3.8'
-    implementation('com.dji:dji-sdk:4.14-trial1', {
+    implementation('com.dji:dji-sdk:4.15', {
         /**
          * Uncomment the "library-anti-distortion" if your app does not need Anti Distortion for Mavic 2 Pro and Mavic 2 Zoom.
          * Uncomment the "fly-safe-database" if you need database for release, or we will download it when DJISDKManager.getInstance().registerApp
@@ -108,9 +108,9 @@ dependencies {
         exclude module: 'library-anti-distortion'
         exclude module: 'fly-safe-database'
     })
-    compileOnly 'com.dji:dji-sdk-provided:4.14-trial1'
+    compileOnly 'com.dji:dji-sdk-provided:4.15'
 
-    implementation 'com.dji:dji-uxsdk:4.14-trial1'
+    implementation 'com.dji:dji-uxsdk:4.15'
 
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,7 @@ android {
         doNotStrip "*/*/libAMapSDK_MAP_v6_9_2.so"
         doNotStrip "*/*/libDJIMOP.so"
         doNotStrip "*/*/libDJISDKLOGJNI.so"
+        doNotStrip "*/*/libgadget.config.so"
 
         exclude 'META-INF/rxjava.properties'
         exclude 'assets/location_map_gps_locked.png'
@@ -77,7 +78,7 @@ android {
         ndk {
             //           abiFilters 'armeabi-v7a'
 //            abiFilters 'armeabi-v7a', 'arm64-v8a'
-            abiFilters 'armeabi-v7a', 'x86', 'arm64-v8a'
+            abiFilters 'armeabi-v7a', 'arm64-v8a'
         }
     }
 
@@ -97,7 +98,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'com.squareup:otto:1.3.8'
-
     implementation('com.dji:dji-sdk:4.14-trial1', {
         /**
          * Uncomment the "library-anti-distortion" if your app does not need Anti Distortion for Mavic 2 Pro and Mavic 2 Zoom.

--- a/app/src/main/cpp/dji_video_jni.c
+++ b/app/src/main/cpp/dji_video_jni.c
@@ -26,7 +26,6 @@ AVFrame *m_pYUVFrame;
 AVCodecContext *m_pCodecCtx;
 AVCodec *m_pAVCodec;
 AVCodecParserContext *m_pCodecPaser;
-static int requestLastKeyframe = 0;
 jmethodID dataCallbackMID;
 
 //FIX
@@ -157,38 +156,16 @@ int parse(JNIEnv *env, jobject obj, uint8_t *pBuff, int videosize, uint64_t pts)
              	m_pCodecPaser->frame_num
              	);*/
 
-            if(m_pCodecPaser->key_frame)
-            {
-                av_free_packet(&lastKeyframe);
-                av_copy_packet(&lastKeyframe, &packet);
-            }
-
-            if(requestLastKeyframe)
-            {
-                requestLastKeyframe = 0;
-                invokeFrameDataCallback(
-                        env,
-                        obj,
-                        lastKeyframe.data,
-                        lastKeyframe.size,
-                        m_pCodecPaser->frame_num,
-                        1,
-                        m_pCodecPaser->width_in_pixel,
-                        m_pCodecPaser->height_in_pixel
-                );
-            } else {
-                invokeFrameDataCallback(
-                        env,
-                        obj,
-                        packet.data,
-                        packet.size,
-                        m_pCodecPaser->frame_num,
-                        m_pCodecPaser->key_frame,
-                        m_pCodecPaser->width_in_pixel,
-                        m_pCodecPaser->height_in_pixel
-                );
-            }
-
+            invokeFrameDataCallback(
+                    env,
+                    obj,
+                    packet.data,
+                    packet.size,
+                    m_pCodecPaser->frame_num,
+                    m_pCodecPaser->key_frame,
+                    m_pCodecPaser->width_in_pixel,
+                    m_pCodecPaser->height_in_pixel
+            );
         }
 
         av_free_packet(&packet);
@@ -267,16 +244,14 @@ Java_sq_rogue_rosettadrone_video_NativeHelper_parse(JNIEnv *env, jobject obj, jb
  */
 JNIEXPORT jboolean
 Java_sq_rogue_rosettadrone_video_NativeHelper_release(JNIEnv *env, jobject obj) {
-    /*if (m_pCodecCtx) {
+    if (m_pCodecCtx) {
         avcodec_close(m_pCodecCtx);
         m_pCodecCtx = NULL;
     }
 
     av_free(m_pYUVFrame);
     av_free(m_pCodecCtx);
-    av_parser_close(m_pCodecPaser);*/
-
-    requestLastKeyframe = 1;
+    av_parser_close(m_pCodecPaser);
 
     return 1;
 }

--- a/app/src/main/cpp/dji_video_jni.c
+++ b/app/src/main/cpp/dji_video_jni.c
@@ -78,7 +78,7 @@ Java_sq_rogue_rosettadrone_video_NativeHelper_init(JNIEnv *env, jobject obj) {
         av_register_all();
         isFFmpegInitialized = 1;
     }
-    m_pAVCodec = avcodec_find_encoder(AV_CODEC_ID_H264);
+    m_pAVCodec = avcodec_find_decoder(AV_CODEC_ID_H264);
     m_pCodecCtx = avcodec_alloc_context3(m_pAVCodec);
     m_pCodecPaser = av_parser_init(AV_CODEC_ID_H264);
     if (m_pAVCodec == NULL || m_pCodecCtx == NULL) {
@@ -145,7 +145,7 @@ int parse(JNIEnv *env, jobject obj, uint8_t *pBuff, int videosize, uint64_t pts)
 
         if (packet.size > 0) {
 
-             LOGD(
+             /*LOGD(
              	"packet size=%d, pts=%lld, width_in_pixel=%d, height_in_pixel=%d, key_frame=%d, frame_has_sps=%d, frame_has_pps=%d, frame_num=%d",
              	packet.size,
              	pts,
@@ -155,7 +155,7 @@ int parse(JNIEnv *env, jobject obj, uint8_t *pBuff, int videosize, uint64_t pts)
              	m_pCodecPaser->frame_has_sps,
              	m_pCodecPaser->frame_has_pps,
              	m_pCodecPaser->frame_num
-             	);
+             	);*/
 
             if(m_pCodecPaser->key_frame)
             {
@@ -242,11 +242,11 @@ Java_sq_rogue_rosettadrone_video_NativeHelper_parse(JNIEnv *env, jobject obj, jb
         // Removing the aud bytes.
         if (size >= fillersize2 &&
             memcmp(fillerbuffer2, buff + size - fillersize2, fillersize2) == 0) {
-            LOGD("Remove filler+AUD");
+            //LOGD("Remove filler+AUD");
             parse(env, obj, buff, size - fillersize2, pts);
         } else if (size >= audaudsize2 &&
                    memcmp(audaudbuffer2, buff + size - audaudsize2, audaudsize2) == 0) {
-            LOGD("Remove AUD+AUD");
+            //LOGD("Remove AUD+AUD");
             parse(env, obj, buff, size - audaudsize2, pts);
         } else if (size >= audsize2 && memcmp(audbuffer2, buff + size - audsize2, audsize2) == 0) {
             //    LOGD("Remove AUD");

--- a/app/src/main/cpp/dji_video_jni.c
+++ b/app/src/main/cpp/dji_video_jni.c
@@ -150,6 +150,9 @@ int parse(JNIEnv *env, jobject obj, uint8_t *pBuff, int videosize, uint64_t pts)
              	m_pCodecPaser->frame_num
              	);
 */
+            if(packet.data[4] == 100)
+                m_pCodecPaser->key_frame = 1;
+                
             invokeFrameDataCallback(
                     env,
                     obj,

--- a/app/src/main/java/sq/rogue/rosettadrone/ConnectionActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/ConnectionActivity.java
@@ -293,7 +293,7 @@ public class ConnectionActivity extends Activity implements View.OnClickListener
         ((TextView) findViewById(R.id.textView2)).setText(getResources().getString(R.string.sdk_version, DJISDKManager.getInstance().getSDKVersion()));
         
         // From here on SDK hooks will be active
-        System.loadLibrary("gadget");
+        //System.loadLibrary("gadget");
     }
 
     private Runnable startApp = new Runnable() {

--- a/app/src/main/java/sq/rogue/rosettadrone/ConnectionActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/ConnectionActivity.java
@@ -291,7 +291,9 @@ public class ConnectionActivity extends Activity implements View.OnClickListener
             ((TextView) findViewById(R.id.textView)).setText(CustomName);
 
         ((TextView) findViewById(R.id.textView2)).setText(getResources().getString(R.string.sdk_version, DJISDKManager.getInstance().getSDKVersion()));
-
+        
+        // From here on SDK hooks will be active
+        System.loadLibrary("gadget");
     }
 
     private Runnable startApp = new Runnable() {

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -823,9 +823,9 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
         djiAircraft.getAirLink().getOcuSyncLink().setChannelSelectionMode(ChannelSelectionMode.AUTO, djiError ->  { if(djiError != null)  Log.e(TAG, djiError.toString());});
         djiAircraft.getAirLink().getOcuSyncLink().setFrequencyBand(OcuSyncFrequencyBand.FREQUENCY_BAND_DUAL, djiError ->  { if(djiError != null)  Log.e(TAG, djiError.toString());});
         djiAircraft.getAirLink().getOcuSyncLink().setChannelBandwidth(OcuSyncBandwidth.Bandwidth20MHz, djiError -> { if(djiError != null)  Log.e(TAG, djiError.toString());});
-       // djiAircraft.getAirLink().getOcuSyncLink().setVideoDataRateCallback(v -> {
-           // VideoFeeder.getInstance().setTranscodingDataRate(v);
-       // });
+        //djiAircraft.getAirLink().getOcuSyncLink().setVideoDataRateCallback(v -> {
+        //   VideoFeeder.getInstance().setTranscodingDataRate(v);
+        //});
 
         djiAircraft.getCamera().setSystemStateCallback(systemState -> {
             if(m_lastSystemState == null)

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -192,7 +192,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
     public AtomicBoolean gimbalReady = null;
     private MiniPID miniPIDSide;
     private MiniPID miniPIDFwd;
-    private MiniPID miniPIDAtti;
+    private MiniPID miniPIDAlti;
 
     private boolean mSafetyEnabled = true;
     private boolean mMotorsArmed = false;
@@ -239,7 +239,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
         // PID for position control...
         miniPIDSide = new MiniPID(0.35, 0.00008, 4.0);
         miniPIDFwd = new MiniPID(0.35, 0.00008, 4.0);
-        miniPIDAtti = new MiniPID(0.35, 0.00008, 4.0);
+        miniPIDAlti = new MiniPID(0.35, 0.00008, 4.0);
         
         //miniPIDSide.setOutputRampRate(0.3);
         //miniPIDFwd.setOutputRampRate(0.3);
@@ -1901,7 +1901,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
 
             miniPIDFwd.reset();
             miniPIDSide.reset();
-            miniPIDAtti.reset();
+            miniPIDAlti.reset();
 
             // This is a non standard trick, but we would like to know exactly when we have reached the position...
             // So we move to AUTO mode while flying to position, and then go back to GUIDED...
@@ -2009,9 +2009,9 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
             miniPIDSide.setOutputFilter(0.1);
             double rightmotion = miniPIDSide.getOutput(-right_dist, 0);
 
-            miniPIDAtti.setOutputLimits(-4.0f, 4.0f);
-            miniPIDAtti.setOutputFilter(0.1);
-            double upmotion = miniPIDAtti.getOutput(coord.getAircraftLocation().getAltitude(), m_Destination_Alt);
+            miniPIDAlti.setOutputLimits(-4.0f, 4.0f);
+            miniPIDAlti.setOutputFilter(0.1);
+            double upmotion = miniPIDAlti.getOutput(coord.getAircraftLocation().getAltitude(), m_Destination_Alt);
 
             speed = 100.0f;
             double clockmotion = m_Destination_Yaw;

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -823,9 +823,10 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
         djiAircraft.getAirLink().getOcuSyncLink().setChannelSelectionMode(ChannelSelectionMode.AUTO, djiError ->  { if(djiError != null)  Log.e(TAG, djiError.toString());});
         djiAircraft.getAirLink().getOcuSyncLink().setFrequencyBand(OcuSyncFrequencyBand.FREQUENCY_BAND_DUAL, djiError ->  { if(djiError != null)  Log.e(TAG, djiError.toString());});
         djiAircraft.getAirLink().getOcuSyncLink().setChannelBandwidth(OcuSyncBandwidth.Bandwidth20MHz, djiError -> { if(djiError != null)  Log.e(TAG, djiError.toString());});
-        djiAircraft.getAirLink().getOcuSyncLink().setVideoDataRateCallback(v -> {
-            VideoFeeder.getInstance().setTranscodingDataRate(v);
-        });
+       // djiAircraft.getAirLink().getOcuSyncLink().setVideoDataRateCallback(v -> {
+           // VideoFeeder.getInstance().setTranscodingDataRate(v);
+       // });
+
         djiAircraft.getCamera().setSystemStateCallback(systemState -> {
             if(m_lastSystemState == null)
                 m_lastSystemState = systemState;

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -615,7 +615,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
                     do_set_motion_absolute(targetLatitude, targetLongitude, targetAltitude, targetHeading <= 180 ? targetHeading : -180 + ((targetHeading) - 180), 2.5f, 2.5f, 2.5f, 2.5f, 0);
                     while(mMoveToDataTimer != null || photoTaken != true)
                     {
-                        ;
+                        safeSleep(100);
                     }
 
                     for (int x = 0; x < currentActions.size(); x++) {
@@ -823,7 +823,9 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
         djiAircraft.getAirLink().getOcuSyncLink().setChannelSelectionMode(ChannelSelectionMode.AUTO, djiError ->  { if(djiError != null)  Log.e(TAG, djiError.toString());});
         djiAircraft.getAirLink().getOcuSyncLink().setFrequencyBand(OcuSyncFrequencyBand.FREQUENCY_BAND_DUAL, djiError ->  { if(djiError != null)  Log.e(TAG, djiError.toString());});
         djiAircraft.getAirLink().getOcuSyncLink().setChannelBandwidth(OcuSyncBandwidth.Bandwidth20MHz, djiError -> { if(djiError != null)  Log.e(TAG, djiError.toString());});
-
+        djiAircraft.getAirLink().getOcuSyncLink().setVideoDataRateCallback(v -> {
+            VideoFeeder.getInstance().setTranscodingDataRate(v);
+        });
         djiAircraft.getCamera().setSystemStateCallback(systemState -> {
             if(m_lastSystemState == null)
                 m_lastSystemState = systemState;
@@ -2050,7 +2052,8 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
             // If there is another way let me know...
             mMoveToDataTask = new MoveTo();
             mMoveToDataTimer = new Timer();
-            mMoveToDataTimer.schedule(mMoveToDataTask, 0, 25);
+
+            mMoveToDataTimer.schedule(mMoveToDataTask, 100, 50);
             mAutonomy = true;
         } else {
             mMoveToDataTask.detection = 0;

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -189,6 +189,8 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
     public boolean photoTaken = false;
     public boolean gotoNoPhoto = false;
     public double m_Curvesize = 0.0;
+    public double m_POI_Lat = 0;
+    public double m_POI_Lon = 0;
     public AtomicBoolean gimbalReady = null;
     private MiniPID miniPIDSide;
     private MiniPID miniPIDFwd;
@@ -833,6 +835,11 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
         msg_autopilot_version msg = new msg_autopilot_version();
         msg.capabilities = MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_COMMAND_INT;
         msg.capabilities |= MAV_PROTOCOL_CAPABILITY.MAV_PROTOCOL_CAPABILITY_MISSION_INT;
+        msg.os_sw_version = 0x040107;
+        msg.middleware_sw_version = 0x040107;
+        msg.flight_sw_version = 0x040107;
+        msg.compid = 0;
+        
         sendMessage(msg);
     }
 
@@ -1937,11 +1944,17 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
             double yaw = coord.getAttitude().yaw;
             if (yaw < 0) yaw = yaw + 360.0;
 
+            double brngPoi = m_Destination_Yaw;
+            if(m_POI_Lon != 0.0 && m_POI_Lat != 0.0)
+            {
+                brngPoi = getBearingBetweenWaypoints(m_POI_Lat, m_POI_Lon, local_lat, local_lon);
+            }
+
             // If yaw is masked then do not change yaw...
             double yawerror;
             if ((m_Destination_Mask & 0b0000010000000000) > 0) yawerror = 0;
                 // Make the error +-180 deg. error  + is we need to turn more right...mAutonomy
-            else yawerror = rotation(m_Destination_Yaw, yaw);
+            else yawerror = rotation(brngPoi, yaw);
             
             //yawerror = 0;
 

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -820,10 +820,10 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
 
         // Deal with OcuSync
         // if()...
-        djiAircraft.getAirLink().getOcuSyncLink().setChannelSelectionMode(ChannelSelectionMode.AUTO, djiError ->  { if(djiError != null)  Log.d(TAG, djiError.toString());});
-        djiAircraft.getAirLink().getOcuSyncLink().setFrequencyBand(OcuSyncFrequencyBand.FREQUENCY_BAND_DUAL, djiError ->  { if(djiError != null)  Log.d(TAG, djiError.toString());});
-        djiAircraft.getAirLink().getOcuSyncLink().setChannelBandwidth(OcuSyncBandwidth.Bandwidth20MHz, djiError -> { if(djiError != null)  Log.d(TAG, djiError.toString());});
-        
+        djiAircraft.getAirLink().getOcuSyncLink().setChannelSelectionMode(ChannelSelectionMode.AUTO, djiError ->  { if(djiError != null)  Log.e(TAG, djiError.toString());});
+        djiAircraft.getAirLink().getOcuSyncLink().setFrequencyBand(OcuSyncFrequencyBand.FREQUENCY_BAND_DUAL, djiError ->  { if(djiError != null)  Log.e(TAG, djiError.toString());});
+        djiAircraft.getAirLink().getOcuSyncLink().setChannelBandwidth(OcuSyncBandwidth.Bandwidth20MHz, djiError -> { if(djiError != null)  Log.e(TAG, djiError.toString());});
+
         djiAircraft.getCamera().setSystemStateCallback(systemState -> {
             if(m_lastSystemState == null)
                 m_lastSystemState = systemState;
@@ -2142,7 +2142,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
                 offset *= -1;
             }
 
-            Log.i(TAG, "diff: " + diff + "brng: " + brng + " hypotenuse: " + hypotenuse + " offset: " + offset + " pol: " + pol);
+            //Log.i(TAG, "diff: " + diff + "brng: " + brng + " hypotenuse: " + hypotenuse + " offset: " + offset + " pol: " + pol);
 
             // Drone heading - Waypoint bearing... to 0-360 deg...
             double direction = rotation(brng, yaw);
@@ -2150,7 +2150,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
             // Find the X and Y distance from the hypotenuse and the direction...
             double right_dist = offset; //Math.max(offset,20); // bearing_error; //Math.sin(Math.toRadians(direction)) * hypotenuse + Math.cos(Math.toRadians(direction)) * bearing_error ;
             double fw_dist = hypotenuse; //Math.max(hypotenuse,20); // Math.cos(Math.toRadians(direction)) * hypotenuse + Math.sin(Math.toRadians(direction)) * bearing_error;
-            Log.i(TAG, "direction: " + direction);
+            //Log.i(TAG, "direction: " + direction);
 
             if(m_CruisingMode)
             {
@@ -2194,10 +2194,10 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
                 do_set_motion_velocity((float) 0, (float) 0, (float) 0, (float) clockmotion, 0b1111011111111111);
             } else {
 
-                Log.i(TAG, "fwmotion: " + fwmotion + " rightmotion: " + rightmotion);
+               // Log.i(TAG, "fwmotion: " + fwmotion + " rightmotion: " + rightmotion);
                 double fmove = Math.cos(Math.toRadians(direction)) * fwmotion - Math.sin(Math.toRadians(direction)) * rightmotion;
                 double rmove = Math.sin(Math.toRadians(direction)) * fwmotion + Math.cos(Math.toRadians(direction)) * rightmotion;
-                Log.i(TAG, "rmove: " + rmove + " fmove: " + fmove);
+                //Log.i(TAG, "rmove: " + rmove + " fmove: " + fmove);
 
                 do_set_motion_velocity((float) fmove, (float) rmove, (float) upmotion, (float) clockmotion, 0b1111011111000111);
                 //do_set_motion_velocity((float) fwmotion, (float) rightmotion, (float) upmotion, (float) clockmotion, 0b1111011111000111);
@@ -2311,7 +2311,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
                 }
                 if (++report > 1) {
                     report = 0;
-                    Log.e(TAG, ":" + mPitch + " " + mRoll + " " + mYaw + " " + mThrottle);
+                    //Log.e(TAG, ":" + mPitch + " " + mRoll + " " + mYaw + " " + mThrottle);
 //                parent.logMessageDJI(":"+mPitch+" "+ mRoll+" "+ mYaw+" "+ mThrottle);
                 }
 
@@ -2391,8 +2391,9 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
 
     void takePhoto() {
         // Wait till Gimbal is in Place
-        while(!gimbalReady.get())
-            ; // Block Thread
+        //while(!gimbalReady.get())
+        //    ; // Block Thread
+        safeSleep(100);
 
         djiAircraft.getCamera().setMode(SettingsDefinitions.CameraMode.SHOOT_PHOTO, djiError -> {
             if(djiError != null) {

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -573,7 +573,11 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
                         case START_TAKE_PHOTO:
                             gotoNoPhoto = false;
                             break;
-
+                        case GIMBAL_PITCH:
+                            // TODO
+                            // Doublecheck vals
+                            //currentTask.gimbalPitch = currentAction.actionParam;
+                            break;
                         default:
                             break;
                     }
@@ -589,8 +593,9 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
 
                     float targetAltitude = currentTask.altitude;
 
-                    float targetGimbalPitch = currentTask.gimbalPitch;
-                    do_set_Gimbal(9, targetGimbalPitch);
+                    // Lets just do it manually for now
+                    //float targetGimbalPitch = currentTask.gimbalPitch;
+                    //do_set_Gimbal(9, targetGimbalPitch);
 
                     float targetSpeed = currentTask.speed;
                     m_CruisingMode = targetSpeed <= 3.0;
@@ -605,7 +610,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
                     {
                         do_takeoff(targetAltitude);
                     }*/
-
+                    
                     // Goto Action
                     do_set_motion_absolute(targetLatitude, targetLongitude, targetAltitude, targetHeading <= 180 ? targetHeading : -180 + ((targetHeading) - 180), 2.5f, 2.5f, 2.5f, 2.5f, 0);
                     while(mMoveToDataTimer != null || photoTaken != true)

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -189,6 +189,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
     public boolean photoTaken = false;
     private MiniPID miniPIDSide;
     private MiniPID miniPIDFwd;
+    private MiniPID miniPIDAtti;
 
     private boolean mSafetyEnabled = true;
     private boolean mMotorsArmed = false;
@@ -232,7 +233,8 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
         // PID for position control...
         miniPIDSide = new MiniPID(0.35, 0.00008, 4.0);
         miniPIDFwd = new MiniPID(0.35, 0.00008, 4.0);
-
+        miniPIDAtti = new MiniPID(0.35, 0.00008, 4.0);
+        
         //miniPIDSide.setOutputRampRate(0.3);
         //miniPIDFwd.setOutputRampRate(0.3);
 
@@ -1894,6 +1896,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
 
             miniPIDFwd.reset();
             miniPIDSide.reset();
+            miniPIDAtti.reset();
 
             // This is a non standard trick, but we would like to know exactly when we have reached the position...
             // So we move to AUTO mode while flying to position, and then go back to GUIDED...
@@ -1991,9 +1994,9 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
             double fwmotion = miniPIDFwd.getOutput(-fw_dist, 0);
             miniPIDSide.setOutputLimits(-12.0f, 12.0f);
             double rightmotion = miniPIDSide.getOutput(-right_dist, 0);
-            double upmotion = (m_Destination_Alt - coord.getAircraftLocation().getAltitude()) * motion_p;
-            if (upmotion > speed) upmotion = speed;
-            if (upmotion < -speed) upmotion = -speed;
+
+            miniPIDAtti.setOutputLimits(-4.0f, 4.0f);
+            double upmotion = miniPIDAtti.getOutput(coord.getAircraftLocation().getAltitude(), m_Destination_Alt);
 
             speed = 100.0f;
             double clockmotion = m_Destination_Yaw;

--- a/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/DroneModel.java
@@ -50,6 +50,7 @@ import java.net.PortUnreachableException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -216,7 +217,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
     private boolean mMotorsArmed = false;
     private FollowMeMissionOperator fmmo;
     public FlightController mFlightController;
-    private Gimbal mGimbal = null;
+    private List<Gimbal> mGimbalList = null;
     private Rotation mRotation = null;
     private boolean m_Sim = false;
 
@@ -276,7 +277,7 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
                 avtivemode = HardwareState.FlightModeSwitch.POSITION_THREE;
             }
 
-            mGimbal = aircraft.getGimbals().get(0);
+            mGimbalList = aircraft.getGimbals();
             mFlightController = aircraft.getFlightController();
             mFlightController.setRollPitchControlMode(RollPitchControlMode.VELOCITY);
             mFlightController.setYawControlMode(YawControlMode.ANGULAR_VELOCITY);
@@ -1942,7 +1943,8 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
             send_command_ack(MAV_CMD_DO_SET_SERVO, MAV_RESULT.MAV_RESULT_UNSUPPORTED);
             return;
         }
-        if (mGimbal == null) {
+        if (mGimbalList == null) {
+            // Some Race on Init or no Gimbal? TODO: Try reinit later?
             send_command_ack(MAV_CMD_DO_SET_SERVO, MAV_RESULT.MAV_RESULT_TEMPORARILY_REJECTED);
             return;
         }
@@ -1950,7 +1952,8 @@ public class DroneModel implements CommonCallbacks.CompletionCallback {
         m_ServoSet = builder.build();
 
         gimbalReady.set(false);
-        mGimbal.rotate(m_ServoSet, djiError -> {
+        // Just get first for now
+        mGimbalList.get(0).rotate(m_ServoSet, djiError -> {
             if (djiError != null)
                 parent.logMessageDJI("Error: " + djiError.toString());
 

--- a/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
@@ -511,11 +511,12 @@ public class MAVLinkReceiver {
         mModel.setGCSCommandedMode(flightMode);
 
         if (flightMode == ArduCopterFlightModes.AUTO) {
-            if (mModel.getWaypointMissionOperator().getCurrentState() == WaypointMissionState.EXECUTION_PAUSED) {
+            if (mModel.m_activeWaypointMission != null && mModel.pauseWaypointMission) {
                 Log.d(TAG, "Resuming mission");
                 mModel.resumeWaypointMission();
-            } else if (mModel.getWaypointMissionOperator().getCurrentState() == WaypointMissionState.READY_TO_EXECUTE)
+            } else if(mModel.m_activeWaypointMission != null) {
                 mModel.startWaypointMission();
+            }
         } else if (flightMode == ArduCopterFlightModes.BRAKE) {
             mModel.pauseWaypointMission();
             mModel.setGCSCommandedMode(flightMode);

--- a/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
@@ -33,6 +33,7 @@ import dji.common.mission.waypoint.WaypointMissionGotoWaypointMode;
 import dji.common.mission.waypoint.WaypointMissionHeadingMode;
 import dji.common.mission.waypoint.WaypointMissionState;
 
+import static com.MAVLink.ardupilotmega.msg_autopilot_version_request.MAVLINK_MSG_ID_AUTOPILOT_VERSION_REQUEST;
 import static com.MAVLink.common.msg_command_int.MAVLINK_MSG_ID_COMMAND_INT;
 import static com.MAVLink.common.msg_command_long.MAVLINK_MSG_ID_COMMAND_LONG;
 import static com.MAVLink.common.msg_heartbeat.MAVLINK_MSG_ID_HEARTBEAT;
@@ -117,6 +118,12 @@ public class MAVLinkReceiver {
         }
 
         switch (msg.msgid) {
+            case MAVLINK_MSG_ID_AUTOPILOT_VERSION_REQUEST:
+                Log.d(TAG, "send_autopilot_version...");
+                mModel.send_command_ack(MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES, MAV_RESULT.MAV_RESULT_ACCEPTED);
+                mModel.send_autopilot_version();
+                break;
+                
             case MAVLINK_MSG_ID_HEARTBEAT:
                 this.mTimeStampLastGCSHeartbeat = System.currentTimeMillis();
                 break;
@@ -171,6 +178,7 @@ public class MAVLinkReceiver {
                         mModel.send_home_position();
                         break;
                     case MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES:
+                        Log.d(TAG, "send_autopilot_version...");
                         mModel.send_autopilot_version();
                         break;
                     case MAV_CMD_VIDEO_START_CAPTURE:

--- a/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
@@ -621,6 +621,14 @@ public class MAVLinkReceiver {
                         currentWP.cornerRadiusInMeters = flightPathRadius;
                     }
 
+                    // If we use trigger distance, for now just add a stay & photo action
+                    // Ideally feed them pre-processed for now
+                    if(triggerDistanceEnabled)
+                    {
+                        currentWP.addAction(new WaypointAction(WaypointActionType.STAY, 0));
+                        currentWP.addAction(new WaypointAction(WaypointActionType.START_TAKE_PHOTO, 0));
+                    }
+
                     dji_wps.add(currentWP);
                 break;
 
@@ -669,6 +677,7 @@ public class MAVLinkReceiver {
                             triggerDistance = m.param1;
                         } else {
                             triggerDistance = 0;
+                            triggerDistanceEnabled = false;
                         }
                     }
                     break;

--- a/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MAVLinkReceiver.java
@@ -431,7 +431,7 @@ public class MAVLinkReceiver {
 
                 // Somehow the GOTO from QGroundControl does not issue a mission count...
                 if (mMissionItemList == null && msg_item.command == MAV_CMD_NAV_WAYPOINT) {
-                    Log.d(TAG, "Goto old... ");
+                    Log.d(TAG, "Goto... ");
                     mModel.goto_position(msg_item.x, msg_item.y, msg_item.z, 0);
                     mModel.send_command_ack(MAVLINK_MSG_ID_MISSION_ACK, MAV_RESULT.MAV_RESULT_ACCEPTED);
 

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -704,11 +704,35 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
                 String strHeading = columns[3];
                 float heading = Float.parseFloat(strHeading);
 
-                // Take Photo
-                if(actionType1 != 1)
-                    mModel.gotoNoPhoto = true;
+                String strCurveSize = columns[4];
+                double curveSize = Double.parseDouble(strCurveSize);
 
-                mModel.do_set_motion_absolute(latitude, longitude, altitude, heading, 2.5f, 2.5f, 2.5f, 2.5f, 0);
+                // Min dist to target
+                // Useful for fly-by
+                mModel.m_Curvesize = Math.max(curveSize, 0.5);
+
+                switch(actionType1)
+                {
+                    // Take Photo
+                    case 1:
+                        mModel.gotoNoPhoto = false;
+                        break;
+                    // Start Recording
+                    case 2:
+                        mModel.gotoNoPhoto = true;
+                        mModel.startRecordingVideo();
+                        break;
+                    // Stop Recording
+                    case 3:
+                        mModel.gotoNoPhoto = true;
+                        mModel.stopRecordingVideo();
+                        break;
+                    default:
+                        mModel.gotoNoPhoto = true;
+                        break;
+                }
+                
+                mModel.do_set_motion_absolute(latitude, longitude, altitude, heading <= 180 ? heading : -180 + ((heading) - 180), 2.5f, 2.5f, 2.5f, 2.5f, 0);
                 while(mModel.mMoveToDataTimer != null ||  mModel.photoTaken != true)
                 {
                     ;
@@ -819,12 +843,12 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
                     });
                 }
 
-                mCamera.setVideoResolutionAndFrameRate(new ResolutionAndFrameRate(SettingsDefinitions.VideoResolution.RESOLUTION_1280x720,SettingsDefinitions.VideoFrameRate.FRAME_RATE_60_FPS) , djiError -> {
+                /*mCamera.setVideoResolutionAndFrameRate(new ResolutionAndFrameRate(SettingsDefinitions.VideoResolution.RESOLUTION_1280x720,SettingsDefinitions.VideoFrameRate.FRAME_RATE_60_FPS) , djiError -> {
                     if (djiError != null) {
                         Log.e(TAG, "can't change mode of camera, error: "+djiError);
                         logMessageDJI("can't change mode of camera, error: "+djiError);
                     }
-                });
+                });*/
 
                 //When calibration is needed or the fetch key frame is required by SDK, should use the provideTranscodedVideoFeed
                 //to receive the transcoded video feed from main camera.

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -769,6 +769,10 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
                 }
             }
            
+            mModel.m_CruisingMode = false;
+            mModel.m_POI_Lat = 0.0;
+            mModel.m_POI_Lon = 0.0;
+
             mModel.do_go_home();
         }
     };

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -680,11 +680,15 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
                 if(row.startsWith(";"))
                     continue;
-
+                
+                // TODO: check isNumeric / if a header is present
                 String[] columns = row.split(",", 0);
                 //;latitude,longitude,altitude(m),heading(deg),curvesize(m),rotationdir,gimbalmode,gimbalpitchangle,actiontype1,actionparam1,actiontype2,actionparam2,actiontype3,actionparam3,actiontype4,actionparam4,actiontype5,actionparam5,actiontype6,actionparam6,actiontype7,actionparam7,actiontype8,actionparam8,actiontype9,actionparam9,actiontype10,actionparam10,actiontype11,actionparam11,actiontype12,actionparam12,actiontype13,actionparam13,actiontype14,actionparam14,actiontype15,actionparam15,altitudemode,speed(m/s),poi_latitude,poi_longitude,poi_altitude(m),poi_altitudemode,photo_timeinterval,photo_distinterval
                 String strGimbalPitch = columns[7];
+                String strActionType1 = columns[8];
                 float gimbalPitch = Float.parseFloat(strGimbalPitch);
+                // TODO: Iterate actionType 1-15
+                int actionType1 = Integer.parseInt(strActionType1);
 
                 // Absolute pitch
                 mModel.do_set_Gimbal(9, gimbalPitch);
@@ -699,6 +703,10 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
                 String strHeading = columns[3];
                 float heading = Float.parseFloat(strHeading);
+
+                // Take Photo
+                if(actionType1 != 1)
+                    mModel.gotoNoPhoto = true;
 
                 mModel.do_set_motion_absolute(latitude, longitude, altitude, heading, 2.5f, 2.5f, 2.5f, 2.5f, 0);
                 while(mModel.mMoveToDataTimer != null ||  mModel.photoTaken != true)

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -201,7 +201,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     private SurfaceView videostreamPreviewTtViewSmall;
     private CodecOutputSurface mCodecOutputSurface;
     private CodecOutputSurface mTranscodeOutputSurface;
-    
+
     private Camera mCamera;
     private DJICodecManager mCodecManager;
     private int videoViewWidth;
@@ -303,6 +303,13 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         DJIVideoStreamDecoder.getInstance().resume();
 
         mCodecManager = new DJICodecManager(getApplicationContext(), mTranscodeOutputSurface.getSurfaceTexture(), 1280, 720, UsbAccessoryService.VideoStreamSource.Camera);
+
+        /*mCodecManager.enabledYuvData(true);
+        mCodecManager.setYuvDataCallback((mediaFormat, byteBuffer, i, i1, i2) -> {
+            mTranscodeOutputSurface.awaitNewImage();
+            mTranscodeOutputSurface.drawImage(true);
+            return;
+        });*/
     }
 
     // After the service have started...

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -693,6 +693,12 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
                 // Absolute pitch
                 mModel.do_set_Gimbal(9, gimbalPitch);
 
+                String strPOILatitude = columns[40];
+                String strPOILongitude = columns[41];
+                // Disabled is 0 / 0
+                double poiLatitude = Double.parseDouble(strPOILatitude);
+                double poiLongitude = Double.parseDouble(strPOILongitude);
+
                 String strLatitude = columns[0];
                 String strLongitude = columns[1];
                 double latitude = Double.parseDouble(strLatitude);
@@ -732,6 +738,11 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
                         break;
                 }
                 
+                mModel.m_POI_Lat = poiLatitude;
+                mModel.m_POI_Lon = poiLongitude;
+
+                Log.e(TAG, "Waypoints: m_POI_Lon: " + poiLongitude + " m_POI_Lat: " + poiLatitude);
+
                 mModel.do_set_motion_absolute(latitude, longitude, altitude, heading <= 180 ? heading : -180 + ((heading) - 180), 2.5f, 2.5f, 2.5f, 2.5f, 0);
                 while(mModel.mMoveToDataTimer != null ||  mModel.photoTaken != true)
                 {

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -282,7 +282,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         mIsTranscodedVideoFeedNeeded = isTranscodedVideoFeedNeeded();
         if (mIsTranscodedVideoFeedNeeded) {
             // The one were we get transcode data...
-            mVideoBitrate = 40;
+            mVideoBitrate = 10;
             VideoFeeder.getInstance().setTranscodingDataRate(mVideoBitrate);
             logMessageDJI("set rate to " + mVideoBitrate);
         }

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -968,6 +968,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
             case PHANTOM_3_PROFESSIONAL:
             case Phantom_3_4K:
             case MAVIC_MINI:
+            case DJI_MINI_2: // Verified...
             case MAVIC_PRO:
             case INSPIRE_1:
             case Spark:

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -1933,6 +1933,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
     //---------------------------------------------------------------------------------------
     //endregion
+    // TODO: Move to own file, credit sources
     /**
      * Holds state associated with a Surface used for MediaCodec decoder output.
      * <p>

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -1009,7 +1009,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
         @Override
         public void surfaceDestroyed(SurfaceHolder holder) {
-                DJIVideoStreamDecoder.getInstance().stop();
+                //DJIVideoStreamDecoder.getInstance().stop();
                 // ohno
                 //NativeHelper.getInstance().release();
             }

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -933,6 +933,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
                     }
                 });*/
 
+                NativeHelper.getInstance().init();
                 //When calibration is needed or the fetch key frame is required by SDK, should use the provideTranscodedVideoFeed
                 //to receive the transcoded video feed from main camera.
                 if (mIsTranscodedVideoFeedNeeded) {
@@ -993,7 +994,6 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     private SurfaceHolder.Callback mSurfaceCallback = new SurfaceHolder.Callback() {
         @Override
         public void surfaceCreated(SurfaceHolder holder) {
-            NativeHelper.getInstance().init();
             DJIVideoStreamDecoder.getInstance().init(getApplicationContext(), holder.getSurface());
             DJIVideoStreamDecoder.getInstance().resume();
         }

--- a/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/MainActivity.java
@@ -14,12 +14,16 @@ import android.content.pm.ActivityInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
+import android.graphics.Bitmap;
 import android.graphics.SurfaceTexture;
 import android.graphics.drawable.Drawable;
 import android.hardware.usb.UsbManager;
 import android.media.Ringtone;
 import android.media.RingtoneManager;
 import android.net.Uri;
+import android.opengl.GLES11Ext;
+import android.opengl.GLES20;
+import android.opengl.Matrix;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -31,6 +35,7 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.TextureView;
@@ -76,12 +81,21 @@ import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLContext;
+import javax.microedition.khronos.egl.EGLDisplay;
+import javax.microedition.khronos.egl.EGLSurface;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
@@ -184,6 +198,7 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
     protected VideoFeeder.VideoDataListener mReceivedVideoDataListener;
     private SurfaceView videostreamPreviewTtView;
     private SurfaceView videostreamPreviewTtViewSmall;
+    
     private Camera mCamera;
     private DJICodecManager mCodecManager;
     private int videoViewWidth;
@@ -270,8 +285,9 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         //------------------------------------------------------------
         videostreamPreviewTtView = findViewById(R.id.livestream_preview_ttv);
         videostreamPreviewTtViewSmall = findViewById(R.id.livestream_preview_ttv_small);
+
+        videostreamPreviewTtView.getHolder().addCallback(mSurfaceCallback);
         videostreamPreviewTtView.setVisibility(View.VISIBLE);
-        //videostreamPreviewTtViewSmall.setVisibility(View.VISIBLE);
     }
 
     // After the service have started...
@@ -1908,5 +1924,517 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
 
     //---------------------------------------------------------------------------------------
     //endregion
+    /**
+     * Holds state associated with a Surface used for MediaCodec decoder output.
+     * <p>
+     * The constructor for this class will prepare GL, create a SurfaceTexture,
+     * and then create a Surface for that SurfaceTexture.  The Surface can be passed to
+     * MediaCodec.configure() to receive decoder output.  When a frame arrives, we latch the
+     * texture with updateTexImage(), then render the texture with GL to a pbuffer.
+     * <p>
+     * By default, the Surface will be using a BufferQueue in asynchronous mode, so we
+     * can potentially drop frames.
+     */
+    private static class CodecOutputSurface
+            implements SurfaceTexture.OnFrameAvailableListener {
+        private STextureRender mTextureRender;
+        private SurfaceTexture mSurfaceTexture;
+        private Surface mSurface;
+        private EGL10 mEgl;
 
+        private EGLDisplay mEGLDisplay = EGL10.EGL_NO_DISPLAY;
+        private EGLContext mEGLContext = EGL10.EGL_NO_CONTEXT;
+        private EGLSurface mEGLSurface = EGL10.EGL_NO_SURFACE;
+        int mWidth;
+        int mHeight;
+
+        private Object mFrameSyncObject = new Object();     // guards mFrameAvailable
+        private boolean mFrameAvailable;
+
+        private ByteBuffer mPixelBuf;                       // used by saveFrame()
+
+        /**
+         * Creates a CodecOutputSurface backed by a pbuffer with the specified dimensions.  The
+         * new EGL context and surface will be made current.  Creates a Surface that can be passed
+         * to MediaCodec.configure().
+         */
+        public CodecOutputSurface(int width, int height) {
+            if (width <= 0 || height <= 0) {
+                throw new IllegalArgumentException();
+            }
+            mEgl = (EGL10) EGLContext.getEGL();
+            mWidth = width;
+            mHeight = height;
+
+            eglSetup();
+            makeCurrent();
+            setup();
+        }
+
+        /**
+         * Creates interconnected instances of TextureRender, SurfaceTexture, and Surface.
+         */
+        private void setup() {
+            mTextureRender = new STextureRender();
+            mTextureRender.surfaceCreated();
+
+            mSurfaceTexture = new SurfaceTexture(mTextureRender.getTextureId());
+
+            // This doesn't work if this object is created on the thread that CTS started for
+            // these test cases.
+            //
+            // The CTS-created thread has a Looper, and the SurfaceTexture constructor will
+            // create a Handler that uses it.  The "frame available" message is delivered
+            // there, but since we're not a Looper-based thread we'll never see it.  For
+            // this to do anything useful, CodecOutputSurface must be created on a thread without
+            // a Looper, so that SurfaceTexture uses the main application Looper instead.
+            //
+            // Java language note: passing "this" out of a constructor is generally unwise,
+            // but we should be able to get away with it here.
+            mSurfaceTexture.setOnFrameAvailableListener(this);
+
+            mSurface = new Surface(mSurfaceTexture);
+
+            mPixelBuf = ByteBuffer.allocateDirect(mWidth * mHeight * 4);
+            mPixelBuf.order(ByteOrder.LITTLE_ENDIAN);
+        }
+
+        /**
+         * Prepares EGL.  We want a GLES 2.0 context and a surface that supports pbuffer.
+         */
+        private void eglSetup() {
+            final int EGL_OPENGL_ES2_BIT = 0x0004;
+            final int EGL_CONTEXT_CLIENT_VERSION = 0x3098;
+
+            mEGLDisplay = mEgl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
+            if (mEGLDisplay == EGL10.EGL_NO_DISPLAY) {
+                throw new RuntimeException("unable to get EGL14 display");
+            }
+            int[] version = new int[2];
+            if (!mEgl.eglInitialize(mEGLDisplay, version)) {
+                mEGLDisplay = null;
+                throw new RuntimeException("unable to initialize EGL14");
+            }
+
+            // Configure EGL for pbuffer and OpenGL ES 2.0, 24-bit RGB.
+            int[] attribList = {
+                    EGL10.EGL_RED_SIZE, 8,
+                    EGL10.EGL_GREEN_SIZE, 8,
+                    EGL10.EGL_BLUE_SIZE, 8,
+                    EGL10.EGL_ALPHA_SIZE, 8,
+                    EGL10.EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+                    EGL10.EGL_SURFACE_TYPE, EGL10.EGL_PBUFFER_BIT,
+                    EGL10.EGL_NONE
+            };
+            EGLConfig[] configs = new EGLConfig[1];
+            int[] numConfigs = new int[1];
+            if (!mEgl.eglChooseConfig(mEGLDisplay, attribList, configs, configs.length,
+                    numConfigs)) {
+                throw new RuntimeException("unable to find RGB888+recordable ES2 EGL config");
+            }
+
+            // Configure context for OpenGL ES 2.0.
+            int[] attrib_list = {
+                    EGL_CONTEXT_CLIENT_VERSION, 2,
+                    EGL10.EGL_NONE
+            };
+            mEGLContext = mEgl.eglCreateContext(mEGLDisplay, configs[0], EGL10.EGL_NO_CONTEXT,
+                    attrib_list);
+            checkEglError("eglCreateContext");
+            if (mEGLContext == null) {
+                throw new RuntimeException("null context");
+            }
+
+            // Create a pbuffer surface.
+            int[] surfaceAttribs = {
+                    EGL10.EGL_WIDTH, mWidth,
+                    EGL10.EGL_HEIGHT, mHeight,
+                    EGL10.EGL_NONE
+            };
+            mEGLSurface = mEgl.eglCreatePbufferSurface(mEGLDisplay, configs[0], surfaceAttribs);
+            checkEglError("eglCreatePbufferSurface");
+            if (mEGLSurface == null) {
+                throw new RuntimeException("surface was null");
+            }
+        }
+
+        /**
+         * Discard all resources held by this class, notably the EGL context.
+         */
+        public void release() {
+            if (mEGLDisplay != EGL10.EGL_NO_DISPLAY) {
+                mEgl.eglDestroySurface(mEGLDisplay, mEGLSurface);
+                mEgl.eglDestroyContext(mEGLDisplay, mEGLContext);
+                //mEgl.eglReleaseThread();
+                mEgl.eglMakeCurrent(mEGLDisplay, EGL10.EGL_NO_SURFACE, EGL10.EGL_NO_SURFACE,
+                        EGL10.EGL_NO_CONTEXT);
+                mEgl.eglTerminate(mEGLDisplay);
+            }
+            mEGLDisplay = EGL10.EGL_NO_DISPLAY;
+            mEGLContext = EGL10.EGL_NO_CONTEXT;
+            mEGLSurface = EGL10.EGL_NO_SURFACE;
+
+            mSurface.release();
+
+            // this causes a bunch of warnings that appear harmless but might confuse someone:
+            //  W BufferQueue: [unnamed-3997-2] cancelBuffer: BufferQueue has been abandoned!
+            //mSurfaceTexture.release();
+
+            mTextureRender = null;
+            mSurface = null;
+            mSurfaceTexture = null;
+        }
+
+        /**
+         * Makes our EGL context and surface current.
+         */
+        public void makeCurrent() {
+            if (!mEgl.eglMakeCurrent(mEGLDisplay, mEGLSurface, mEGLSurface, mEGLContext)) {
+                throw new RuntimeException("eglMakeCurrent failed");
+            }
+        }
+
+        /**
+         * Returns the Surface.
+         */
+        public Surface getSurface() {
+            return mSurface;
+        }
+
+        /**
+         * Latches the next buffer into the texture.  Must be called from the thread that created
+         * the CodecOutputSurface object.  (More specifically, it must be called on the thread
+         * with the EGLContext that contains the GL texture object used by SurfaceTexture.)
+         */
+        public void awaitNewImage() {
+            final int TIMEOUT_MS = 2500;
+
+            synchronized (mFrameSyncObject) {
+                while (!mFrameAvailable) {
+                    try {
+                        // Wait for onFrameAvailable() to signal us.  Use a timeout to avoid
+                        // stalling the test if it doesn't arrive.
+                        mFrameSyncObject.wait(TIMEOUT_MS);
+                        if (!mFrameAvailable) {
+                            // TODO: if "spurious wakeup", continue while loop
+                            throw new RuntimeException("frame wait timed out");
+                        }
+                    } catch (InterruptedException ie) {
+                        // shouldn't happen
+                        throw new RuntimeException(ie);
+                    }
+                }
+                mFrameAvailable = false;
+            }
+
+            // Latch the data.
+            mTextureRender.checkGlError("before updateTexImage");
+            mSurfaceTexture.updateTexImage();
+        }
+
+        /**
+         * Draws the data from SurfaceTexture onto the current EGL surface.
+         *
+         * @param invert if set, render the image with Y inverted (0,0 in top left)
+         */
+        public void drawImage(boolean invert) {
+            mTextureRender.drawFrame(mSurfaceTexture, invert);
+        }
+
+        // SurfaceTexture callback
+        @Override
+        public void onFrameAvailable(SurfaceTexture st) {
+            Log.d(MainActivity.class.getSimpleName(), "new frame available");
+            synchronized (mFrameSyncObject) {
+                if (mFrameAvailable) {
+                    throw new RuntimeException("mFrameAvailable already set, frame could be dropped");
+                }
+                mFrameAvailable = true;
+                mFrameSyncObject.notifyAll();
+            }
+        }
+
+        /**
+         * Saves the current frame to disk as a PNG image.
+         */
+        public void saveFrame(String filename) throws IOException {
+            // glReadPixels gives us a ByteBuffer filled with what is essentially big-endian RGBA
+            // data (i.e. a byte of red, followed by a byte of green...).  To use the Bitmap
+            // constructor that takes an int[] array with pixel data, we need an int[] filled
+            // with little-endian ARGB data.
+            //
+            // If we implement this as a series of buf.get() calls, we can spend 2.5 seconds just
+            // copying data around for a 720p frame.  It's better to do a bulk get() and then
+            // rearrange the data in memory.  (For comparison, the PNG compress takes about 500ms
+            // for a trivial frame.)
+            //
+            // So... we set the ByteBuffer to little-endian, which should turn the bulk IntBuffer
+            // get() into a straight memcpy on most Android devices.  Our ints will hold ABGR data.
+            // Swapping B and R gives us ARGB.  We need about 30ms for the bulk get(), and another
+            // 270ms for the color swap.
+            //
+            // We can avoid the costly B/R swap here if we do it in the fragment shader (see
+            // http://stackoverflow.com/questions/21634450/ ).
+            //
+            // Having said all that... it turns out that the Bitmap#copyPixelsFromBuffer()
+            // method wants RGBA pixels, not ARGB, so if we create an empty bitmap and then
+            // copy pixel data in we can avoid the swap issue entirely, and just copy straight
+            // into the Bitmap from the ByteBuffer.
+            //
+            // Making this even more interesting is the upside-down nature of GL, which means
+            // our output will look upside-down relative to what appears on screen if the
+            // typical GL conventions are used.  (For ExtractMpegFrameTest, we avoid the issue
+            // by inverting the frame when we render it.)
+            //
+            // Allocating large buffers is expensive, so we really want mPixelBuf to be
+            // allocated ahead of time if possible.  We still get some allocations from the
+            // Bitmap / PNG creation.
+
+            mPixelBuf.rewind();
+            GLES20.glReadPixels(0, 0, mWidth, mHeight, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE,
+                mPixelBuf);
+
+            BufferedOutputStream bos = null;
+            try {
+                bos = new BufferedOutputStream(new FileOutputStream(filename));
+                Bitmap bmp = Bitmap.createBitmap(mWidth, mHeight, Bitmap.Config.ARGB_8888);
+                mPixelBuf.rewind();
+                bmp.copyPixelsFromBuffer(mPixelBuf);
+                bmp.compress(Bitmap.CompressFormat.PNG, 90, bos);
+                bmp.recycle();
+            } finally {
+                if (bos != null) bos.close();
+            }
+            Log.d(MainActivity.class.getSimpleName(), "Saved " + mWidth + "x" + mHeight + " frame as '" + filename + "'");
+        }
+
+        /**
+         * Checks for EGL errors.
+         */
+        private void checkEglError(String msg) {
+            int error;
+            if ((error = mEgl.eglGetError()) != EGL10.EGL_SUCCESS) {
+                throw new RuntimeException(msg + ": EGL error: 0x" + Integer.toHexString(error));
+            }
+        }
+    }
+
+
+    /**
+     * Code for rendering a texture onto a surface using OpenGL ES 2.0.
+     */
+    private static class STextureRender {
+        private static final int FLOAT_SIZE_BYTES = 4;
+        private static final int TRIANGLE_VERTICES_DATA_STRIDE_BYTES = 5 * FLOAT_SIZE_BYTES;
+        private static final int TRIANGLE_VERTICES_DATA_POS_OFFSET = 0;
+        private static final int TRIANGLE_VERTICES_DATA_UV_OFFSET = 3;
+        private final float[] mTriangleVerticesData = {
+                // X, Y, Z, U, V
+                -1.0f, -1.0f, 0, 0.f, 0.f,
+                 1.0f, -1.0f, 0, 1.f, 0.f,
+                -1.0f,  1.0f, 0, 0.f, 1.f,
+                 1.0f,  1.0f, 0, 1.f, 1.f,
+        };
+
+        private FloatBuffer mTriangleVertices;
+
+        private static final String VERTEX_SHADER =
+                "uniform mat4 uMVPMatrix;\n" +
+                "uniform mat4 uSTMatrix;\n" +
+                "attribute vec4 aPosition;\n" +
+                "attribute vec4 aTextureCoord;\n" +
+                "varying vec2 vTextureCoord;\n" +
+                "void main() {\n" +
+                "    gl_Position = uMVPMatrix * aPosition;\n" +
+                "    vTextureCoord = (uSTMatrix * aTextureCoord).xy;\n" +
+                "}\n";
+
+        private static final String FRAGMENT_SHADER =
+                "#extension GL_OES_EGL_image_external : require\n" +
+                "precision mediump float;\n" +      // highp here doesn't seem to matter
+                "varying vec2 vTextureCoord;\n" +
+                "uniform samplerExternalOES sTexture;\n" +
+                "void main() {\n" +
+                "    gl_FragColor = texture2D(sTexture, vTextureCoord);\n" +
+                "}\n";
+
+        private float[] mMVPMatrix = new float[16];
+        private float[] mSTMatrix = new float[16];
+
+        private int mProgram;
+        private int mTextureID = -12345;
+        private int muMVPMatrixHandle;
+        private int muSTMatrixHandle;
+        private int maPositionHandle;
+        private int maTextureHandle;
+
+        public STextureRender() {
+            mTriangleVertices = ByteBuffer.allocateDirect(
+                    mTriangleVerticesData.length * FLOAT_SIZE_BYTES)
+                    .order(ByteOrder.nativeOrder()).asFloatBuffer();
+            mTriangleVertices.put(mTriangleVerticesData).position(0);
+
+            Matrix.setIdentityM(mSTMatrix, 0);
+        }
+
+        public int getTextureId() {
+            return mTextureID;
+        }
+
+        /**
+         * Draws the external texture in SurfaceTexture onto the current EGL surface.
+         */
+        public void drawFrame(SurfaceTexture st, boolean invert) {
+            checkGlError("onDrawFrame start");
+            st.getTransformMatrix(mSTMatrix);
+            if (invert) {
+                mSTMatrix[5] = -mSTMatrix[5];
+                mSTMatrix[13] = 1.0f - mSTMatrix[13];
+            }
+
+            // (optional) clear to green so we can see if we're failing to set pixels
+            GLES20.glClearColor(0.0f, 1.0f, 0.0f, 1.0f);
+            GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+
+            GLES20.glUseProgram(mProgram);
+            checkGlError("glUseProgram");
+
+            GLES20.glActiveTexture(GLES20.GL_TEXTURE0);
+            GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, mTextureID);
+
+            mTriangleVertices.position(TRIANGLE_VERTICES_DATA_POS_OFFSET);
+            GLES20.glVertexAttribPointer(maPositionHandle, 3, GLES20.GL_FLOAT, false,
+                    TRIANGLE_VERTICES_DATA_STRIDE_BYTES, mTriangleVertices);
+            checkGlError("glVertexAttribPointer maPosition");
+            GLES20.glEnableVertexAttribArray(maPositionHandle);
+            checkGlError("glEnableVertexAttribArray maPositionHandle");
+
+            mTriangleVertices.position(TRIANGLE_VERTICES_DATA_UV_OFFSET);
+            GLES20.glVertexAttribPointer(maTextureHandle, 2, GLES20.GL_FLOAT, false,
+                    TRIANGLE_VERTICES_DATA_STRIDE_BYTES, mTriangleVertices);
+            checkGlError("glVertexAttribPointer maTextureHandle");
+            GLES20.glEnableVertexAttribArray(maTextureHandle);
+            checkGlError("glEnableVertexAttribArray maTextureHandle");
+
+            Matrix.setIdentityM(mMVPMatrix, 0);
+            GLES20.glUniformMatrix4fv(muMVPMatrixHandle, 1, false, mMVPMatrix, 0);
+            GLES20.glUniformMatrix4fv(muSTMatrixHandle, 1, false, mSTMatrix, 0);
+
+            GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4);
+            checkGlError("glDrawArrays");
+
+            GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, 0);
+        }
+
+        /**
+         * Initializes GL state.  Call this after the EGL surface has been created and made current.
+         */
+        public void surfaceCreated() {
+            mProgram = createProgram(VERTEX_SHADER, FRAGMENT_SHADER);
+            if (mProgram == 0) {
+                throw new RuntimeException("failed creating program");
+            }
+
+            maPositionHandle = GLES20.glGetAttribLocation(mProgram, "aPosition");
+            checkLocation(maPositionHandle, "aPosition");
+            maTextureHandle = GLES20.glGetAttribLocation(mProgram, "aTextureCoord");
+            checkLocation(maTextureHandle, "aTextureCoord");
+
+            muMVPMatrixHandle = GLES20.glGetUniformLocation(mProgram, "uMVPMatrix");
+            checkLocation(muMVPMatrixHandle, "uMVPMatrix");
+            muSTMatrixHandle = GLES20.glGetUniformLocation(mProgram, "uSTMatrix");
+            checkLocation(muSTMatrixHandle, "uSTMatrix");
+
+            int[] textures = new int[1];
+            GLES20.glGenTextures(1, textures, 0);
+
+            mTextureID = textures[0];
+            GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, mTextureID);
+            checkGlError("glBindTexture mTextureID");
+
+            GLES20.glTexParameterf(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER,
+                    GLES20.GL_NEAREST);
+            GLES20.glTexParameterf(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER,
+                    GLES20.GL_LINEAR);
+            GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S,
+                    GLES20.GL_CLAMP_TO_EDGE);
+            GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T,
+                    GLES20.GL_CLAMP_TO_EDGE);
+            checkGlError("glTexParameter");
+        }
+
+        /**
+         * Replaces the fragment shader.  Pass in null to reset to default.
+         */
+        public void changeFragmentShader(String fragmentShader) {
+            if (fragmentShader == null) {
+                fragmentShader = FRAGMENT_SHADER;
+            }
+            GLES20.glDeleteProgram(mProgram);
+            mProgram = createProgram(VERTEX_SHADER, fragmentShader);
+            if (mProgram == 0) {
+                throw new RuntimeException("failed creating program");
+            }
+        }
+
+        private int loadShader(int shaderType, String source) {
+            int shader = GLES20.glCreateShader(shaderType);
+            checkGlError("glCreateShader type=" + shaderType);
+            GLES20.glShaderSource(shader, source);
+            GLES20.glCompileShader(shader);
+            int[] compiled = new int[1];
+            GLES20.glGetShaderiv(shader, GLES20.GL_COMPILE_STATUS, compiled, 0);
+            if (compiled[0] == 0) {
+                Log.e(MainActivity.class.getSimpleName(), "Could not compile shader " + shaderType + ":");
+                Log.e(MainActivity.class.getSimpleName(), " " + GLES20.glGetShaderInfoLog(shader));
+                GLES20.glDeleteShader(shader);
+                shader = 0;
+            }
+            return shader;
+        }
+
+        private int createProgram(String vertexSource, String fragmentSource) {
+            int vertexShader = loadShader(GLES20.GL_VERTEX_SHADER, vertexSource);
+            if (vertexShader == 0) {
+                return 0;
+            }
+            int pixelShader = loadShader(GLES20.GL_FRAGMENT_SHADER, fragmentSource);
+            if (pixelShader == 0) {
+                return 0;
+            }
+
+            int program = GLES20.glCreateProgram();
+            if (program == 0) {
+                Log.e(MainActivity.class.getSimpleName(), "Could not create program");
+            }
+            GLES20.glAttachShader(program, vertexShader);
+            checkGlError("glAttachShader");
+            GLES20.glAttachShader(program, pixelShader);
+            checkGlError("glAttachShader");
+            GLES20.glLinkProgram(program);
+            int[] linkStatus = new int[1];
+            GLES20.glGetProgramiv(program, GLES20.GL_LINK_STATUS, linkStatus, 0);
+            if (linkStatus[0] != GLES20.GL_TRUE) {
+                Log.e(MainActivity.class.getSimpleName(), "Could not link program: ");
+                Log.e(MainActivity.class.getSimpleName(), GLES20.glGetProgramInfoLog(program));
+                GLES20.glDeleteProgram(program);
+                program = 0;
+            }
+            return program;
+        }
+
+        public void checkGlError(String op) {
+            int error;
+            while ((error = GLES20.glGetError()) != GLES20.GL_NO_ERROR) {
+                Log.e(MainActivity.class.getSimpleName(), op + ": glError " + error);
+                throw new RuntimeException(op + ": glError " + error);
+            }
+        }
+
+        public static void checkLocation(int location, String label) {
+            if (location < 0) {
+                throw new RuntimeException("Unable to locate '" + label + "' in program");
+            }
+        }
+    }
 }

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -404,7 +404,9 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
             this.surface = surface;
             if(surface == null)
                 surface = this.outputSurface.getSurface();
-            codec.setOutputSurface(surface);
+
+            if(codec != null)
+                codec.setOutputSurface(surface);
         }
     }
 

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -292,7 +292,7 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
 
         try {
             // Create the codec instance.
-            codec = MediaCodec.createByCodecName("OMX.google.h264.decoder");
+            codec = MediaCodec.createDecoderByType(VIDEO_ENCODING_FORMAT);
             logd( "initVideoDecoder create: " + (codec == null));
             // Configure the codec. What should be noted here is that the hardware decoder would not output
             // any yuv data if a surface is configured into, which mean that if you want the yuv frames, you

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -273,7 +273,7 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
 
         try {
             // Create the codec instance.
-            codec = MediaCodec.createDecoderByType(VIDEO_ENCODING_FORMAT);
+            codec = MediaCodec.createByCodecName("OMX.google.h264.decoder");
             logd( "initVideoDecoder create: " + (codec == null));
             // Configure the codec. What should be noted here is that the hardware decoder would not output
             // any yuv data if a surface is configured into, which mean that if you want the yuv frames, you

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -265,7 +265,7 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
             return;
         }
         if (codec != null) {
-            releaseCodec();
+            return;
         }
         loge("initVideoDecoder----------------------------------------------------------");
         loge("initVideoDecoder video width = " + width + "  height = " + height);
@@ -405,8 +405,9 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
             if(surface == null)
                 surface = this.outputSurface.getSurface();
 
-            if(codec != null)
+            if(codec != null) {
                 codec.setOutputSurface(surface);
+            }
         }
     }
 
@@ -511,14 +512,15 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private void decodeFrame() throws Exception {
-        DJIFrame inputFrame = frameQueue.poll();
-        if (inputFrame == null) {
-            return;
-        }
         if (codec == null) {
             if (dataHandler != null && !dataHandler.hasMessages(MSG_INIT_CODEC)) {
                 dataHandler.sendEmptyMessage(MSG_INIT_CODEC);
             }
+            return;
+        }
+
+        DJIFrame inputFrame = frameQueue.poll();
+        if (inputFrame == null) {
             return;
         }
 
@@ -560,11 +562,11 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
                 // not, so that the codec can reuse the buffer.
                 codec.releaseOutputBuffer(outIndex, true);
                 
-                if(this.surface == this.outputSurface.getSurface())
+                /*if(this.surface == this.outputSurface.getSurface())
                 {
                     this.outputSurface.awaitNewImage();
                     this.outputSurface.drawImage(true);
-                }
+                }*/
             } else if (outIndex == MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED) {
                 // The output buffer set is changed. So the decoder should be reinitialized and the
                 // output buffers should be retrieved.

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -57,7 +57,7 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
     public static final String VIDEO_ENCODING_FORMAT = "video/avc";
     private HandlerThread  handlerThreadNew;
     private Handler handlerNew;
-    private final boolean DEBUG = true;
+    private final boolean DEBUG = false;
     private static DJIVideoStreamDecoder instance;
     private Queue<DJIFrame> frameQueue;
     private HandlerThread dataHandlerThread;

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -1,0 +1,597 @@
+package sq.rogue.rosettadrone.video;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.media.MediaCodec;
+import android.media.MediaCodecInfo;
+import android.media.MediaFormat;
+import android.os.Build;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.Message;
+import android.util.Log;
+import android.view.Surface;
+
+import dji.common.product.Model;
+import dji.log.DJILog;
+import dji.midware.data.model.P3.DataCameraGetPushStateInfo;
+import dji.sdk.codec.DJICodecManager;
+import dji.sdk.products.Aircraft;
+import dji.sdk.sdkmanager.DJISDKManager;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import dji.sdk.base.BaseProduct;
+import sq.rogue.rosettadrone.R;
+
+/**
+ * This class is a helper class for hardware decoding. Please follow the following steps to use it:
+ *
+ * 1. Initialize and set the instance as a listener of NativeDataListener to receive the frame data.
+ *
+ * 2. Send the raw data from camera to ffmpeg for frame parsing.
+ *
+ * 3. Get the parsed frame data from ffmpeg parsing frame callback and cache the parsed framed data into the frameQueue.
+ *
+ * 4. Initialize the MediaCodec as a decoder and then check whether there is any i-frame in the MediaCodec. If not, get
+ * the default i-frame from sdk resource and insert it at the head of frameQueue. Then dequeue the framed data from the
+ * frameQueue and feed it(which is Byte buffer) into the MediaCodec.
+ *
+ * 5. Get the output byte buffer from MediaCodec, if a surface(Video Previewing View) is configured in the MediaCodec,
+ * the output byte buffer is only need to be released. If not, the output yuv data should invoke the callback and pass
+ * it out to external listener, it should also be released too.
+ *
+ * 6. Release the ffmpeg and the MediaCodec, stop the decoding thread.
+ */
+public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
+    private static final String TAG = DJIVideoStreamDecoder.class.getSimpleName();
+    private static final int BUF_QUEUE_SIZE = 60;
+    private static final int MSG_INIT_CODEC = 0;
+    private static final int MSG_FRAME_QUEUE_IN = 1;
+    private static final int MSG_DECODE_FRAME = 2;
+    private static final int MSG_YUV_DATA = 3;
+    public static final String VIDEO_ENCODING_FORMAT = "video/avc";
+    private HandlerThread  handlerThreadNew;
+    private Handler handlerNew;
+    private final boolean DEBUG = true;
+    private static DJIVideoStreamDecoder instance;
+    private Queue<DJIFrame> frameQueue;
+    private HandlerThread dataHandlerThread;
+    private Handler dataHandler;
+    private Context context;
+    private MediaCodec codec;
+    private Surface surface;
+
+    public int frameIndex = -1;
+    private long currentTime;
+    public int width;
+    public int height;
+    private boolean hasIFrameInQueue = false;
+    MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
+    LinkedList<Long> bufferChangedQueue=new LinkedList<Long>();
+
+    private long createTime;
+
+    /**
+     * Set the yuv frame data receiving callback. The callback method will be invoked when the decoder
+     * output yuv frame data. What should be noted here is that the hardware decoder would not output
+     * any yuv data if a surface is configured into, which mean that if you want the yuv frames, you
+     * should set "null" surface when calling the "configure" method of MediaCodec.
+     * @param yuvDataListener
+     */
+    public void setYuvDataListener(DJICodecManager.YuvDataCallback yuvDataListener) {
+        this.yuvDataListener = yuvDataListener;
+    }
+
+    private DJICodecManager.YuvDataCallback yuvDataListener;
+
+    /**
+     * A data structure for containing the frames.
+     */
+    private static class DJIFrame {
+        public byte[] videoBuffer;
+        public int size;
+        public long pts;
+        public long incomingTimeMs;
+        public long fedIntoCodecTime;
+        public long codecOutputTime;
+        public boolean isKeyFrame;
+        public int frameNum;
+        public long frameIndex;
+        public int width;
+        public int height;
+
+        public DJIFrame(byte[] videoBuffer, int size, long pts, long incomingTimeUs, boolean isKeyFrame,
+                        int frameNum, long frameIndex, int width, int height){
+            this.videoBuffer=videoBuffer;
+            this.size=size;
+            this.pts =pts;
+            this.incomingTimeMs=incomingTimeUs;
+            this.isKeyFrame=isKeyFrame;
+            this.frameNum=frameNum;
+            this.frameIndex=frameIndex;
+            this.width=width;
+            this.height=height;
+        }
+
+        public long getQueueDelay()
+        {
+            return fedIntoCodecTime-incomingTimeMs;
+        }
+
+        public long getDecodingDelay()
+        {
+            return codecOutputTime-fedIntoCodecTime;
+        }
+
+        public long getTotalDelay()
+        {
+            return codecOutputTime-fedIntoCodecTime;
+        }
+    }
+
+    private void logd(String tag, String log) {
+        if (!DEBUG) {
+            return;
+        }
+        Log.d(tag, log);
+    }
+    private void loge(String tag, String log) {
+        if (!DEBUG) {
+            return;
+        }
+        Log.e(tag, log);
+    }
+
+    private void logd(String log) {
+        logd(TAG, log);
+    }
+    private void loge(String log) {
+        loge(TAG, log);
+    }
+
+    private DJIVideoStreamDecoder() {
+        createTime = System.currentTimeMillis();
+        frameQueue = new ArrayBlockingQueue<DJIFrame>(BUF_QUEUE_SIZE);
+        startDataHandler();
+        handlerThreadNew = new HandlerThread("native parser thread");
+        handlerThreadNew.start();
+        handlerNew = new Handler(handlerThreadNew.getLooper(), new Handler.Callback() {
+            @Override
+            public boolean handleMessage(Message msg) {
+                byte[] buf = (byte[])msg.obj;
+                NativeHelper.getInstance().parse(buf, msg.arg1, 0);
+                return false;
+            }
+        });
+    }
+
+
+    public synchronized static DJIVideoStreamDecoder getInstance() {
+        if (instance == null) {
+            instance = new DJIVideoStreamDecoder();
+        }
+        return instance;
+    }
+
+    /**
+     * Initialize the decoder
+     * @param context The application context
+     * @param surface The displaying surface for the video stream. What should be noted here is that the hardware decoder would not output
+     * any yuv data if a surface is configured into, which mean that if you want the yuv frames, you
+     * should set "null" surface when calling the "configure" method of MediaCodec.
+     */
+    public void init(Context context, Surface surface) {
+        this.context = context;
+        this.surface = surface;
+        NativeHelper.getInstance().setDataListener(this);
+        if (dataHandler != null && !dataHandler.hasMessages(MSG_INIT_CODEC)) {
+            dataHandler.sendEmptyMessage(MSG_INIT_CODEC);
+        }
+    }
+
+    /**
+     * Framing the raw data from the camera.
+     * @param buf Raw data from camera.
+     * @param size Data length
+     */
+    public void parse(byte[] buf, int size) {
+        Message message =handlerNew.obtainMessage();
+        message.obj = buf;
+        message.arg1 = size;
+        handlerNew.sendMessage(message);
+    }
+
+    /**
+     * Get the resource ID of the IDR frame.
+     * @param pModel Product model of connecting DJI product.
+     * @param width Width of current video stream.
+     * @return Resource ID of the IDR frame
+     */
+    public int getIframeRawId(Model pModel, int width) {
+        return R.raw.iframe_1280x720_wm220;
+    }
+
+    /** Get default black IDR frame.
+     * @param width Width of current video stream.
+     * @return IDR frame data
+     * @throws IOException
+     */
+    private byte[] getDefaultKeyFrame(int width) throws IOException {
+        BaseProduct product = DJISDKManager.getInstance().getProduct();
+        if (product == null || product.getModel() == null) {
+            return null;
+        }
+        int iframeId=getIframeRawId(product.getModel(), width);
+        if (iframeId > 0){
+
+            InputStream inputStream = context.getResources().openRawResource(iframeId);
+            int length = inputStream.available();
+            logd("iframeId length=" + length);
+            byte[] buffer = new byte[length];
+            inputStream.read(buffer);
+            inputStream.close();
+
+            return buffer;
+        }
+        return null;
+    }
+
+
+    /**
+     * Initialize the hardware decoder.
+     */
+    private void initCodec() {
+        if (width == 0 || height == 0) {
+            return;
+        }
+        if (codec != null) {
+            releaseCodec();
+        }
+        loge("initVideoDecoder----------------------------------------------------------");
+        loge("initVideoDecoder video width = " + width + "  height = " + height);
+        // create the media format
+        MediaFormat format = MediaFormat.createVideoFormat(VIDEO_ENCODING_FORMAT, width, height);
+        if (surface == null) {
+            logd("initVideoDecoder: yuv output");
+            // The surface is null, which means that the yuv data is needed, so the color format should
+            // be set to YUV420.
+            format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Planar);
+        } else {
+            logd("initVideoDecoder: display");
+            // The surface is set, so the color format should be set to format surface.
+            format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatSurface);
+        }
+
+        format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 0);
+        //format.setInteger(MediaFormat.KEY_MAX_WIDTH, 0);
+        //format.setInteger(MediaFormat.KEY_MAX_HEIGHT, 0);
+
+        try {
+            // Create the codec instance.
+            codec = MediaCodec.createDecoderByType(VIDEO_ENCODING_FORMAT);
+            logd( "initVideoDecoder create: " + (codec == null));
+            // Configure the codec. What should be noted here is that the hardware decoder would not output
+            // any yuv data if a surface is configured into, which mean that if you want the yuv frames, you
+            // should set "null" surface when calling the "configure" method of MediaCodec.
+            codec.configure(format, surface, null, 0);
+            logd( "initVideoDecoder configure");
+            //            codec.configure(format, null, null, 0);
+            if (codec == null) {
+                loge("Can't find video info!");
+                return;
+            }
+            // Start the codec
+            codec.start();
+        } catch (Exception e) {
+            loge("init codec failed, do it again: " + e);
+            e.printStackTrace();
+        }
+    }
+
+    private void startDataHandler() {
+        if (dataHandlerThread != null && dataHandlerThread.isAlive()) {
+            return;
+        }
+        dataHandlerThread = new HandlerThread("frame data handler thread");
+        dataHandlerThread.start();
+        dataHandler = new Handler(dataHandlerThread.getLooper()) {
+            @Override
+            public void handleMessage(Message msg) {
+                switch (msg.what) {
+                    case MSG_INIT_CODEC:
+                        try {
+                            initCodec();
+                        } catch (Exception e) {
+                            loge("init codec error: " + e.getMessage());
+                            e.printStackTrace();
+                        }
+
+                        removeCallbacksAndMessages(null);
+                        sendEmptyMessageDelayed(MSG_DECODE_FRAME, 1);
+                        break;
+                    case MSG_FRAME_QUEUE_IN:
+                        try {
+                            onFrameQueueIn(msg);
+                        } catch (Exception e) {
+                            loge("queue in frame error: " + e);
+                            e.printStackTrace();
+                        }
+
+                        if (!hasMessages(MSG_DECODE_FRAME)) {
+                            sendEmptyMessage(MSG_DECODE_FRAME);
+                        }
+                        break;
+                    case MSG_DECODE_FRAME:
+                        try {
+                            decodeFrame();
+                        } catch (Exception e) {
+                            loge("handle frame error: " + e);
+                            if (e instanceof MediaCodec.CodecException) {
+                            }
+                            e.printStackTrace();
+                            initCodec();
+                        }finally {
+                            if (frameQueue.size() > 0) {
+                                sendEmptyMessage(MSG_DECODE_FRAME);
+                            }
+                        }
+                        break;
+                    case MSG_YUV_DATA:
+
+                        break;
+                    default:
+                        break;
+                }
+            }
+        };
+    }
+
+    /**
+     * Stop the data processing thread
+     */
+    private void stopDataHandler() {
+        if (dataHandlerThread == null || !dataHandlerThread.isAlive()) {
+            return;
+        }
+        if (dataHandler != null) {
+            dataHandler.removeCallbacksAndMessages(null);
+        }
+        if (Build.VERSION.SDK_INT >= 18) {
+            dataHandlerThread.quitSafely();
+        } else {
+            dataHandlerThread.quit();
+        }
+
+        try {
+            dataHandlerThread.join(3000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        releaseCodec();
+        dataHandler = null;
+    }
+
+    /**
+     * Change the displaying surface of the decoder. What should be noted here is that the hardware decoder would not output
+     * any yuv data if a surface is configured into, which mean that if you want the yuv frames, you
+     * should set "null" surface when calling the "configure" method of MediaCodec.
+     * @param surface
+     */
+    public void changeSurface(Surface surface) {
+        if (this.surface != surface) {
+            this.surface = surface;
+            if (dataHandler != null && !dataHandler.hasMessages(MSG_INIT_CODEC)) {
+                dataHandler.sendEmptyMessage(MSG_INIT_CODEC);
+            }
+        }
+    }
+
+    /**
+     * Release and close the codec.
+     */
+    private void releaseCodec() {
+        if (frameQueue!=null){
+            frameQueue.clear();
+            hasIFrameInQueue = false;
+        }
+        if (codec != null) {
+            try {
+                codec.flush();
+            } catch (Exception e) {
+                loge("flush codec error: " + e.getMessage());
+            }
+
+            try {
+                codec.stop();
+                codec.release();
+            } catch (Exception e) {
+                loge("close codec error: " + e.getMessage());
+            } finally {
+                codec = null;
+            }
+        }
+    }
+
+    /**
+     * Queue in the frame.
+     * @param msg
+     */
+    private void onFrameQueueIn(Message msg) {
+        DJIFrame inputFrame = (DJIFrame)msg.obj;
+        if (inputFrame == null) {
+            return;
+        }
+        if (!hasIFrameInQueue) { // check the I frame flag
+            if (inputFrame.frameNum != 0 && !inputFrame.isKeyFrame) {
+                loge("the timing for setting iframe has not yet come frameNum: " + inputFrame.frameNum );
+                return;
+            }
+            byte[] defaultKeyFrame = null;
+            try {
+                defaultKeyFrame = getDefaultKeyFrame(inputFrame.width); // Get I frame data
+            } catch (IOException e) {
+                loge("get default key frame error: " + e.getMessage());
+            }
+             if (inputFrame.isKeyFrame) {
+                hasIFrameInQueue = true;
+            } else {
+                loge("input key frame failed");
+            }
+        }
+        if (inputFrame.width!=0 && inputFrame.height != 0 &&
+            (inputFrame.width != this.width ||
+                inputFrame.height != this.height)) {
+            this.width = inputFrame.width;
+            this.height = inputFrame.height;
+    	   /*
+    	    * On some devices, the codec supports changing of resolution during the fly
+    	    * However, on some devices, that is not the case.
+    	    * So, reset the codec in order to fix this issue.
+    	    */
+            loge("init decoder for the 1st time or when resolution changes");
+            if (dataHandler != null && !dataHandler.hasMessages(MSG_INIT_CODEC)) {
+                dataHandler.sendEmptyMessage(MSG_INIT_CODEC);
+            }
+        }
+        // Queue in the input frame.
+        if (this.frameQueue.offer(inputFrame)){
+            logd("put a frame into the Extended-Queue with index=" + inputFrame.frameIndex);
+        } else {
+            // If the queue is full, drop a frame.
+            DJIFrame dropFrame = frameQueue.poll();
+            this.frameQueue.offer(inputFrame);
+            loge("Drop a frame with index=" + dropFrame.frameIndex+" and append a frame with index=" + inputFrame.frameIndex);
+        }
+    }
+
+    /**
+     * Dequeue the frames from the queue and decode them using the hardware decoder.
+     * @throws Exception
+     */
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private void decodeFrame() throws Exception {
+        DJIFrame inputFrame = frameQueue.poll();
+        if (inputFrame == null) {
+            return;
+        }
+        if (codec == null) {
+            if (dataHandler != null && !dataHandler.hasMessages(MSG_INIT_CODEC)) {
+                dataHandler.sendEmptyMessage(MSG_INIT_CODEC);
+            }
+            return;
+        }
+
+        if(DEBUG)
+            logd("Decoding Frame " + inputFrame.frameIndex);
+
+        int inIndex = codec.dequeueInputBuffer(0);
+
+        // Decode the frame using MediaCodec
+        if (inIndex >= 0) {
+            Log.d(TAG, "decodeFrame: index=" + inIndex);
+            ByteBuffer buffer = codec.getInputBuffer(inIndex);
+            buffer.clear();
+            buffer.limit(buffer.position() + inputFrame.size);
+            buffer.put(inputFrame.videoBuffer);
+            inputFrame.fedIntoCodecTime = System.currentTimeMillis();
+            long queueingDelay = inputFrame.getQueueDelay();
+            // Feed the frame data to the decoder.
+            codec.queueInputBuffer(inIndex, 0, inputFrame.size, inputFrame.pts, 0);
+
+            // Get the output data from the decoder.
+            int outIndex = codec.dequeueOutputBuffer(bufferInfo, 0);
+
+            if(DEBUG)
+                Log.d(TAG, "decodeFrame: outIndex: " + outIndex);
+
+            if (outIndex >= 0) {
+                if (surface == null && yuvDataListener != null) {
+                    // If the surface is null, the yuv data should be get from the buffer and invoke the callback.
+                    logd("decodeFrame: need callback");
+                    ByteBuffer yuvDataBuf = codec.getOutputBuffer(outIndex);
+                    yuvDataBuf.position(bufferInfo.offset);
+                    yuvDataBuf.limit(bufferInfo.size - bufferInfo.offset);
+                    if (yuvDataListener != null) {
+                        yuvDataListener.onYuvDataReceived(codec.getOutputFormat(), yuvDataBuf, bufferInfo.size - bufferInfo.offset,  width, height);
+                    }
+                }
+                // All the output buffer must be release no matter whether the yuv data is output or
+                // not, so that the codec can reuse the buffer.
+                codec.releaseOutputBuffer(outIndex, true);
+            } else if (outIndex == MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED) {
+                // The output buffer set is changed. So the decoder should be reinitialized and the
+                // output buffers should be retrieved.
+                long curTime = System.currentTimeMillis();
+                bufferChangedQueue.addLast(curTime);
+                if (bufferChangedQueue.size() >= 10) {
+                    long headTime = bufferChangedQueue.pollFirst();
+                    if (curTime - headTime < 1000) {
+                        // reset decoder
+                        loge("Reset decoder. Get INFO_OUTPUT_BUFFERS_CHANGED more than 10 times within a second.");
+                        bufferChangedQueue.clear();
+                        dataHandler.removeCallbacksAndMessages(null);
+                        dataHandler.sendEmptyMessage(MSG_INIT_CODEC);
+                        return;
+                    }
+                }
+            } else if (outIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+                loge("format changed, color: " + codec.getOutputFormat().getInteger(MediaFormat.KEY_COLOR_FORMAT));
+            }
+        }else {
+            codec.flush();
+        }
+    }
+
+    /**
+     * Stop the decoding process.
+     */
+    public void stop() {
+        if (dataHandler != null) {
+            dataHandler.removeCallbacksAndMessages(null);
+        }
+
+        if (frameQueue!=null){
+            frameQueue.clear();
+            hasIFrameInQueue = false;
+        }
+        if (codec != null) {
+            try {
+                codec.flush();
+            } catch (IllegalStateException e) {
+            }
+        }
+        stopDataHandler();
+    }
+
+    public void resume() {
+        startDataHandler();
+    }
+
+    public void destroy() {
+    }
+
+    @Override
+    public void onDataRecv(byte[] data, int size, int frameNum, boolean isKeyFrame, int width, int height) {
+        if (dataHandler == null || dataHandlerThread == null || !dataHandlerThread.isAlive()) {
+            return;
+        }
+        
+        if (data.length != size) {
+            loge( "recv data size: " + size + ", data lenght: " + data.length);
+        } else {
+            logd( "recv data size: " + size + ", frameNum: "+frameNum+", isKeyframe: "+isKeyFrame+"," +
+                    " width: "+width+", height: " + height);
+            currentTime = System.currentTimeMillis();
+            frameIndex ++;
+            DJIFrame newFrame = new DJIFrame(data, size, currentTime, currentTime, isKeyFrame, frameNum, frameIndex, width, height);
+            dataHandler.obtainMessage(MSG_FRAME_QUEUE_IN, newFrame).sendToTarget();
+
+        }
+    }
+}

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -592,6 +592,10 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
             DJIFrame newFrame = new DJIFrame(data, size, currentTime, currentTime, isKeyFrame, frameNum, frameIndex, width, height);
             dataHandler.obtainMessage(MSG_FRAME_QUEUE_IN, newFrame).sendToTarget();
 
+            // Pass raw Data further for streaming purposes, not a Yuv..
+            if (yuvDataListener != null) {
+                yuvDataListener.onYuvDataReceived(null,  ByteBuffer.wrap(data), size,  width, height);
+            }
         }
     }
 }

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -557,8 +557,12 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
                 // All the output buffer must be release no matter whether the yuv data is output or
                 // not, so that the codec can reuse the buffer.
                 codec.releaseOutputBuffer(outIndex, true);
-                this.outputSurface.awaitNewImage();
-                this.outputSurface.drawImage(true);
+                
+                if(this.surface == this.outputSurface.getSurface())
+                {
+                    this.outputSurface.awaitNewImage();
+                    this.outputSurface.drawImage(true);
+                }
             } else if (outIndex == MediaCodec.INFO_OUTPUT_BUFFERS_CHANGED) {
                 // The output buffer set is changed. So the decoder should be reinitialized and the
                 // output buffers should be retrieved.

--- a/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/DJIVideoStreamDecoder.java
@@ -52,7 +52,7 @@ import sq.rogue.rosettadrone.R;
  */
 public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
     private static final String TAG = DJIVideoStreamDecoder.class.getSimpleName();
-    private static final int BUF_QUEUE_SIZE = 120;
+    private static final int BUF_QUEUE_SIZE = 60;
     private static final int MSG_INIT_CODEC = 0;
     private static final int MSG_FRAME_QUEUE_IN = 1;
     private static final int MSG_DECODE_FRAME = 2;
@@ -451,7 +451,7 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
             return;
         }
         if (!hasIFrameInQueue) { // check the I frame flag
-            if (inputFrame.frameNum != 1 && !inputFrame.isKeyFrame) {
+            /*if (inputFrame.frameNum != 1 && !inputFrame.isKeyFrame) {
                 loge("Time to set keyframe hasnt come yet");
                 return;
             }
@@ -479,7 +479,7 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
                 logd("add iframe success!!!!");
                 hasIFrameInQueue = true;
             }
-             else if (inputFrame.isKeyFrame) {
+             else */if (inputFrame.isKeyFrame) {
                 hasIFrameInQueue = true;
             } else {
                 loge("input key frame failed");
@@ -637,7 +637,7 @@ public class DJIVideoStreamDecoder implements NativeHelper.NativeDataListener {
             logd( "recv data size: " + size + ", frameNum: "+frameNum+", isKeyframe: "+isKeyFrame+"," +
                     " width: "+width+", height: " + height);
             currentTime = System.currentTimeMillis();
-            frameIndex ++;
+            frameIndex = frameNum;
             DJIFrame newFrame = new DJIFrame(data, size, currentTime, currentTime, isKeyFrame, frameNum, frameIndex, width, height);
             dataHandler.obtainMessage(MSG_FRAME_QUEUE_IN, newFrame).sendToTarget();
       //  }

--- a/app/src/main/java/sq/rogue/rosettadrone/video/VideoService.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/VideoService.java
@@ -106,7 +106,7 @@ public class VideoService extends Service implements NativeHelper.NativeDataList
 
     private void initVideoStreamDecoder() {
         NativeHelper.getInstance().init();
-        NativeHelper.getInstance().setDataListener(this);
+        //NativeHelper.getInstance().setDataListener(this);
     }
 
     private void initPacketizer(String ip, int videoPort, int videoBitrate, int encodeSpeed) {

--- a/app/src/main/java/sq/rogue/rosettadrone/video/VideoService.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/VideoService.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import sq.rogue.rosettadrone.video.DJIVideoStreamDecoder;
 
 public class VideoService extends Service implements NativeHelper.NativeDataListener {
 
@@ -106,6 +107,9 @@ public class VideoService extends Service implements NativeHelper.NativeDataList
 
     private void initVideoStreamDecoder() {
         NativeHelper.getInstance().init();
+        DJIVideoStreamDecoder.getInstance().setYuvDataListener((mediaFormat, byteBuffer, size, w, h) -> {
+            this.onDataRecv(byteBuffer.array(), size, 0, false, 0, 0);
+        });
         //NativeHelper.getInstance().setDataListener(this);
     }
 

--- a/app/src/main/java/sq/rogue/rosettadrone/video/VideoService.java
+++ b/app/src/main/java/sq/rogue/rosettadrone/video/VideoService.java
@@ -106,7 +106,6 @@ public class VideoService extends Service implements NativeHelper.NativeDataList
     }
 
     private void initVideoStreamDecoder() {
-        NativeHelper.getInstance().init();
         DJIVideoStreamDecoder.getInstance().setYuvDataListener((mediaFormat, byteBuffer, size, w, h) -> {
             this.onDataRecv(byteBuffer.array(), size, 0, false, 0, 0);
         });

--- a/app/src/main/jniLibs/arm64-v8a/libgadget.config.so
+++ b/app/src/main/jniLibs/arm64-v8a/libgadget.config.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c1a07e68f73b8b998124fd08c481818eb55c7dedf6bba5d791d875a3d4c23a3
+size 134

--- a/app/src/main/jniLibs/arm64-v8a/libgadget.so
+++ b/app/src/main/jniLibs/arm64-v8a/libgadget.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:274df50bcae95aa677fb56e1edbe0076bc91971dd4b1a4e0b692b562c91a150e
+size 20191104

--- a/app/src/main/jniLibs/armeabi-v7a/libgadget.config.so
+++ b/app/src/main/jniLibs/armeabi-v7a/libgadget.config.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c1a07e68f73b8b998124fd08c481818eb55c7dedf6bba5d791d875a3d4c23a3
+size 134

--- a/app/src/main/jniLibs/armeabi-v7a/libgadget.so
+++ b/app/src/main/jniLibs/armeabi-v7a/libgadget.so
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d274992b93c5ee028440299f827fbee092a8f269deee25b49d42368cac538625
+size 14730448

--- a/app/src/main/res/layout/activity_gui.xml
+++ b/app/src/main/res/layout/activity_gui.xml
@@ -21,7 +21,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent">
 
-        <TextureView
+        <SurfaceView
             android:id="@+id/livestream_preview_ttv"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
@@ -45,7 +45,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent">
 
-        <TextureView
+        <SurfaceView
             android:id="@+id/livestream_preview_ttv_small"
             android:layout_width="164dp"
             android:layout_height="86dp"


### PR DESCRIPTION
Uses Frida to Support the Mini 2 by spoofing the DroneType as Mavic Air 2 and the Camera as Mavic Mini

Known Issues:

    No Yaw limits for Gimbal, potential damage source
    Simulator disconnect while flight makes the gimbal go crazy sometimes, unknown if this can cause potential damage. Persists on short restarts, on coldstart usually works a few times.
    IMU shows abnormal, but no issues occur. Doesnt happen with Mavic Air 2 Camera spoofed
    Mavic Mini Camera doesnt lets you set raw etc in the UX SDK, however its possible to set it in the DJI Fly app and it just keeps the values

Use on your own risk.

You will need to additionally have https://gist.github.com/m4xw/bcd66abb39f711399f7ff2e5b6be20e3 on your SDCard. The location is specified in gadget.config.so (fake shared lib, just a json)

Its inactive if the file isnt found.
I am still not finished tuning it further and i cant recommend people using it widely yet.
**So bold disclaimer**

Waypoint support is done by feeding it a csv in litchie format, i just crudely whipped that up now for metashape mission support.

Results have been very decent. Bare in mind this probably breaks a bunch of other use-cases, I just want to start raising some discussion on the topic!

Example CSV:
![grafik](https://user-images.githubusercontent.com/13141469/119203654-db788680-ba93-11eb-885f-301b8527fa7b.png)

