### PR TITLE
Replace deprecated class

### DIFF
--- a/app/src/androidTest/java/sq/rogue/rosettadrone/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/sq/rogue/rosettadrone/ExampleInstrumentedTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 
 import static org.junit.Assert.assertEquals;
 
@@ -20,7 +20,7 @@ public class ExampleInstrumentedTest {
     @Test
     public void useAppContext() throws Exception {
         // Context of the app under test.
-        Context appContext = InstrumentationRegistry.getTargetContext();
+        Context appContext = ApplicationProvider.getApplicationContext();
 
         assertEquals("io.diux.rogue.rosettadrone", appContext.getPackageName());
     }


### PR DESCRIPTION
InstrumentationRegistry is deprecated
https://developer.android.com/reference/androidx/test/InstrumentationRegistry

I needed this change to build APK