### PR TITLE
Workaround Fixing CI by not using LFS

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,13 @@
 name: Android CI
 
-on: ["push", "pull_request"]
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        branches:
+            - master
+    workflow_dispatch: #Allow triggering builds manually from Actions tab in GitHub
 
 jobs:
   build:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        lfs: true
+        lfs: false
 
     # NDK installation https://github.com/actions/runner-images/issues/60
     - name: Setup Android NDKv2
@@ -20,6 +20,15 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: gradle
+
+    # Manually download library uploaded in mock release:
+    # https://github.com/pktiuk/rosettadrone/releases/tag/libffm
+    - name: Download libffmpeg library (workaround for https://github.com/RosettaDrone/rosettadrone/issues/141 )
+      run: |
+        wget https://github.com/pktiuk/rosettadrone/releases/download/libffmpeg/libffmpeg.zip
+        unzip ./libffmpeg.zip 
+        mv ./arm64-v8a/libffmpeg.so ./app/src/main/cpp/lib/arm64-v8a/
+        mv ./armeabi-v7a/libffmpeg.so ./app/src/main/cpp/lib/armeabi-v7a/
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew


### PR DESCRIPTION
Instead using LFS to obtain these libraries I used libraries ~I uploaded in comment: https://github.com/RosettaDrone/rosettadrone/issues/141#issuecomment-1493857778~ I uploaded in mock release https://github.com/pktiuk/rosettadrone/releases/tag/libffmpeg 
This is not the nicest fix but at least it should work.  Later we should replace it with proper solution.