### PR TITLE
Maintain video feed aspect ratio

### DIFF
--- a/app/src/main/res/layout/activity_gui.xml
+++ b/app/src/main/res/layout/activity_gui.xml
@@ -12,12 +12,11 @@
 
     <FrameLayout
         android:id="@+id/fragment_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:textColor="@color/centerpoint_green"
         android:background="@color/background_blue"
-        android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent">
 
@@ -28,31 +27,6 @@
             android:layout_gravity="bottom|end"
             android:alpha="40"
             android:foregroundGravity="center_horizontal"
-            android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintRight_toRightOf="parent" />
-
-    </FrameLayout>
-
-    <FrameLayout
-        android:id="@+id/fragment_container_small"
-        android:layout_width="164dp"
-        android:layout_height="86dp"
-        android:layout_gravity="bottom|end"
-        android:textColor="@color/centerpoint_green"
-        android:background="@color/background_blue"
-        android:visibility="visible"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toRightOf="parent">
-
-        <TextureView
-            android:id="@+id/livestream_preview_ttv_small"
-            android:layout_width="164dp"
-            android:layout_height="86dp"
-            android:layout_gravity="bottom|end"
-            android:alpha="40"
-            android:foregroundGravity="center_horizontal"
-            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintRight_toRightOf="parent" />
 
@@ -60,11 +34,10 @@
 
     <LinearLayout
         android:id="@+id/map_view"
-        android:layout_width="164dp"
-        android:layout_height="86dp"
+        android:layout_width="160dp"
+        android:layout_height="90dp"
         android:gravity="bottom|end"
         android:orientation="horizontal"
-        android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent">
 
@@ -89,6 +62,21 @@
         -->
     </LinearLayout>
 
+
+    <FrameLayout
+        android:id="@+id/tab_map_video"
+        android:layout_width="160dp"
+        android:layout_height="90dp"
+        android:background="#FF0000"
+        android:gravity="bottom|end"
+        android:onClick="onSmallMapClick"
+        android:clickable="true"
+        android:alpha="0"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintRight_toRightOf="parent">
+    </FrameLayout>
+
+
     <FrameLayout
         android:id="@+id/compass_container"
         android:layout_width="510dp"
@@ -109,22 +97,6 @@
             android:visibility="visible"
             tools:ignore="RtlHardcoded" />
     </FrameLayout>
-
-
-        <FrameLayout
-            android:id="@+id/tab_map_video"
-            android:layout_width="164dp"
-            android:layout_height="86dp"
-            android:layout_marginEnd="5dp"
-            android:layout_marginBottom="10dp"
-            android:background="#FF0000"
-            android:gravity="bottom|end"
-            android:onClick="onSmallMapClick"
-            android:clickable="true"
-            android:alpha="0"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintRight_toRightOf="parent">
-        </FrameLayout>
 
 
     <FrameLayout


### PR DESCRIPTION
| Before | After (4:3) | After (16:9 video) |
| --- | --- | --- |
| ![Screenshot_20240518-153409](https://github.com/RosettaDrone/rosettadrone/assets/1078004/92957fd7-4241-48b1-8838-17dd79718719) | ![Screenshot_20240518-154600](https://github.com/RosettaDrone/rosettadrone/assets/1078004/dda279da-6c5a-48c3-9a19-7197f4f6cd28) | ![Screenshot_20240518-154611](https://github.com/RosettaDrone/rosettadrone/assets/1078004/139c34fd-4cc7-412a-a0ef-f27f32fa9706) |

[video-feed-ratio.webm](https://github.com/RosettaDrone/rosettadrone/assets/1078004/1e68a0e2-166e-44c3-ba61-f1cc5315fcc6)

- [x] Transform texture to maintain the aspect ratio of the current feed
- [x] Recalculate aspect ratio and update the transform matrix as soon as settings change